### PR TITLE
Adjust examples to use to_3d(axes=…)

### DIFF
--- a/examples/ex_01_generate_probe_from_sratch.py
+++ b/examples/ex_01_generate_probe_from_sratch.py
@@ -60,10 +60,10 @@ df
 plot_probe(probe)
 
 ##############################################################################
-# A 2d `Probe` can be transformed to a 3d `Probe` by indicating the `plane`
+# A 2d `Probe` can be transformed to a 3d `Probe` by indicating the `axes`
 # on which contacts will lie (Here the 'y' coordinate will be 0 for all contacts):
 
-probe_3d = probe.to_3d(plane='xz')
+probe_3d = probe.to_3d(axes='xz')
 plot_probe(probe_3d)
 
 plt.show()

--- a/examples/ex_02_probe_2d_probe_3d.py
+++ b/examples/ex_02_probe_2d_probe_3d.py
@@ -33,10 +33,10 @@ probe_2d.create_auto_shape(probe_type='tip')
 ##############################################################################
 # Let's transform it into a 3d probe.
 # 
-# Here the plane is 'xz' so y will be 0 for all contacts.
+# Here the axes are 'xz' so y will be 0 for all contacts.
 # The shape of probe_3d.contact_positions is now (n_elec, 3)
 
-probe_3d = probe_2d.to_3d(plane='xz')
+probe_3d = probe_2d.to_3d(axes='xz')
 print(probe_2d.contact_positions.shape)
 print(probe_3d.contact_positions.shape)
 
@@ -55,7 +55,7 @@ plot_probe(probe_3d)
 # We can create another probe lying on another plane:
 
 
-other_3d = probe_2d.to_3d(plane='yz')
+other_3d = probe_2d.to_3d(axes='yz')
 plot_probe(other_3d)
 
 ##############################################################################


### PR DESCRIPTION
Renaming the keyword parameter `plane` to `axes` in d2cd928 was, strictly speaking, a breaking API change.

This PR adjusts the examples to match the new API.

Fixes:

```
TypeError: to_3d() got an unexpected keyword argument 'plane'
```

when running the examples.