### PR TITLE
Explicitly list packages for setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 
-[tool.setuptools.packages]
-find = {}
+[tool.setuptools]
+packages = ["probeinterface"]
 
 
 [project.optional-dependencies]


### PR DESCRIPTION
This prevents all top-level directories from being installed to `site-packages` (fixes #133).

There are other possible fixes for the issue, but this is a simple one that seemed to work for me.