### PR TITLE
Better handling of contact ids for unknown NP type in OpenEphys

### DIFF
--- a/probeinterface/io.py
+++ b/probeinterface/io.py
@@ -1152,6 +1152,7 @@ def read_openephys(
 
         for i, pos in enumerate(positions):
             if ptype is None:
+                contact_ids = None
                 break
             elif ptype == 0:
                 shank_id = 0
@@ -1307,7 +1308,9 @@ def read_openephys(
         probe_serial_number=np_probe.attrib["probe_serial_number"],
     )
 
-    probe.set_contact_ids( np_probe_info['contact_ids'])
+    if np_probe_info['contact_ids'] is not None:
+        probe.set_contact_ids(np_probe_info['contact_ids'])
+
     # planar contour
     one_polygon = [
         (0, 10000),


### PR DESCRIPTION
It the Neuropixels probe type was unknown (e.g. for NP-Ultra), the `contact_ids` were set to `[]`, which triggered errors whrn running `to_numpy()`.

This PR simply avoids setting contact ids when they ar enot known.