### PR TITLE
added support for NP 1.0-NHP probes for SpikeGLX recordings

### DIFF
--- a/probeinterface/io.py
+++ b/probeinterface/io.py
@@ -767,7 +767,7 @@ npx_probe = {
     },
     # Neuropixels 1.0-NHP 45mm SOI125 - NHP long 125um wide, staggered contacts
     1031: {
-        "x_pitch": 103,
+        "x_pitch": 91,
         "y_pitch": 20,
         "contact_width": 12,
         "shank_pitch": 0,
@@ -921,7 +921,7 @@ def _read_imro_string(imro_str):
     # planar contour
     one_polygon = [(0, 10000), (0, 0), (35, -175), (70, 0), (70, 10000), ]
     nhp90_polygon = [(0, 10000), (0, 0), (45, -342), (90, 0), (90, 10000), ]
-    nhp125_polygon = [(0, 10000), (0, 0), (62, -342), (125, 0), (125, 10000), ]
+    nhp125_polygon = [(0, 10000), (0, 0), (62.5, -342), (125, 0), (125, 10000), ]
     contour = []
     for shank_id in range(npx_probe[imDatPrb_type]["shank_number"]):
         if imDatPrb_type in (1030, ):
@@ -1440,7 +1440,7 @@ def read_openephys(
     nhp125_polygon = [
         (0, 10000),
         (0, 0),
-        (62, -342),
+        (62.5, -342),
         (125, 0),
         (125, 10000),
     ]


### PR DESCRIPTION
Added support for SpikeGLX recordings using [1.0-NHP Neuropixels probes](https://www.neuropixels.org/_files/ugd/328966_97dfdcf9421a41ae9c57c9047928834c.pdf) as per this issue in spikeinterface/spikeinterface#1431 and [SpikeGLX source](SpikeGLX/Src-imro/IMROTbl.cpp)

Tested on a recording acquired with default settings using SpikeGLX release v20230120-phase30 and 45mm (long) 1.0-NHP Neuropixels probes with imDatPrb_type=1030

Probes reference

```
    # Neuropixels 1.0-NHP Short (10mm)
    1015: {
        "x_pitch": 32,
        "y_pitch": 20,
        "contact_width": 12,
        "shank_pitch": 0,
        "shank_number": 1,
        "ncol": 2
    },
    # Neuropixels 1.0-NHP Medium (25mm)
    1022: {
        "x_pitch": 103,
        "y_pitch": 20,
        "contact_width": 12,
        "shank_pitch": 0,
        "shank_number": 1,
        "ncol": 2
    },
    # Neuropixels 1.0-NHP 45mm SOI90 - NHP long 90um wide, staggered contacts 
    1030: {
        "x_pitch": 56,
        "y_pitch": 20,
        "contact_width": 12,
        "shank_pitch": 0,
        "shank_number": 1,
        "ncol": 2
    },
    # Neuropixels 1.0-NHP 45mm SOI125 - NHP long 125um wide, staggered contacts
    1031: {
        "x_pitch": 91,
        "y_pitch": 20,
        "contact_width": 12,
        "shank_pitch": 0,
        "shank_number": 1,
        "ncol": 2
    },  
    # 1.0-NHP 45mm SOI115 / 125 linear - NHP long 125um wide, linear contacts
    1032: {
        "x_pitch": 103,
        "y_pitch": 20,
        "contact_width": 12,
        "shank_pitch": 0,
        "shank_number": 1,
        "ncol": 2
    }
```
