### PR TITLE
Update test workflow to use latest version of actions

### DIFF
--- a/.github/workflows/full_tests.yml
+++ b/.github/workflows/full_tests.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: "3.11"
     - name: Install Tools
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/full_tests.yml
+++ b/.github/workflows/full_tests.yml
@@ -3,7 +3,7 @@ name: Test on Ubuntu
 on:
   pull_request:
       branches: [main]
-      types: [synchronize, opened, reopened, ready_for_review]
+      types: [synchronize, opened, reopened]
 
 jobs:
   build-and-test:
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.11
     - name: Install Tools
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Couple of things in this PR:
1) Update the actions versions.
2) Use a newer version of Python
3) Eliminate `ready_for_review` condition (I don't see the point of this if it was tested again when it was synchronized). Maybe @samuelgarcia would like some of this small power saving ; )
4) Re-name the yml file to `full_tests.yml`

Let's leave testing other operating systems for later. 