### PR TITLE
Add safe import

### DIFF
--- a/probeinterface/io.py
+++ b/probeinterface/io.py
@@ -19,6 +19,7 @@ import numpy as np
 from . import __version__
 from .probe import Probe
 from .probegroup import ProbeGroup
+from .utils import import_safely
 
 
 
@@ -121,7 +122,7 @@ def read_BIDS_probe(folder, prefix=None):
 
     """
 
-    import pandas as pd
+    pd = import_safely("pandas")
 
     folder = Path(folder)
     probes = {}
@@ -326,8 +327,8 @@ def write_BIDS_probe(folder, probe_or_probegroup, prefix=""):
 
     """
 
-    import pandas as pd
-
+    pd = import_safely("pandas")
+    
     if isinstance(probe_or_probegroup, Probe):
         probe = probe_or_probegroup
         probegroup = ProbeGroup()
@@ -519,11 +520,8 @@ def read_maxwell(file, well_name="well000", rec_name="rec0000"):
     file = Path(file).absolute()
     assert file.is_file()
 
-    try:
-        import h5py
-    except ImportError as error:
-        print(error.__class__.__name__ + ": " + error.message)
-
+    
+    h5py = import_safely("h5py")
     my_file = h5py.File(file, mode="r")
 
     if "mapping" in my_file.keys():
@@ -590,11 +588,7 @@ def read_3brain(file, mea_pitch=42, electrode_width=21):
     file = Path(file).absolute()
     assert file.is_file()
 
-    try:
-        import h5py
-    except ImportError as error:
-        print(error.__class__.__name__ + ": " + error.message)
-
+    h5py = import_safely("h5py")
     rf = h5py.File(file, "r")
 
     # get channel positions
@@ -1159,7 +1153,8 @@ def read_openephys(
     probe : Probe object
 
     """
-    import xml.etree.ElementTree as ET
+
+    ET = import_safely("xml.etree.ElementTree")
     # parse xml
     tree = ET.parse(str(settings_file))
     root = tree.getroot()
@@ -1489,10 +1484,7 @@ def read_mearec(file):
     file = Path(file).absolute()
     assert file.is_file()
 
-    try:
-        import h5py
-    except ImportError as error:
-        print(error.__class__.__name__ + ": " + error.message)
+    h5py = import_safely("h5py")
 
     f = h5py.File(file, "r")
     positions = f["channel_positions"][()]

--- a/probeinterface/utils.py
+++ b/probeinterface/utils.py
@@ -1,10 +1,49 @@
 """
 Some utility functions
 """
+from importlib import import_module
+from types import ModuleType
+
 import numpy as np
 
 from .probe import Probe
 
+def import_safely(module: str) -> ModuleType:
+    """
+    Safely import a module with importlib and return the imported module object.
+
+    Parameters
+    ----------
+    module : str
+        The name of the module to import.
+
+    Returns
+    -------
+    module_obj : module
+        The imported module object.
+
+    Raises
+    ------
+    ImportError
+        If the specified module cannot be imported.
+
+    Examples
+    --------
+    >>> import math
+    >>> math_module = import_safely("math")
+    >>> math_module.sqrt(4)
+    2.0
+
+    >>> import_safely("non_existent_module")
+    ImportError: No module named 'non_existent_module'
+    """
+
+    try:
+        module_obj = import_module(module)
+    except ImportError as error:
+        raise ImportError(f"{repr(error)}")
+
+    return module_obj
 
 def combine_probes(probes, connect_shape=True):
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+
+import pytest 
+
+from probeinterface.utils import import_safely
+
+def test_good_import():
+    
+    np = import_safely('numpy')
+    np.__name__ == 'numpy'
+    
+def test_handle_import_error():
+    with pytest.raises(ImportError):
+        import_safely('not_a_real_package')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ from probeinterface.utils import import_safely
 def test_good_import():
     
     np = import_safely('numpy')
-    np.__name__ == 'numpy'
+    assert np.__name__ == 'numpy'
     
 def test_handle_import_error():
     with pytest.raises(ImportError):


### PR DESCRIPTION
Commonly we use the pattern for safe import of:
```
try:
  import package
except:
  raise
```
This PR centralizes this logic using importlib to have a place where the logic of failure is handled and adds a test.