### PR TITLE
Extend probe constructor

### DIFF
--- a/src/probeinterface/library.py
+++ b/src/probeinterface/library.py
@@ -71,7 +71,7 @@ def get_from_cache(manufacturer, probe_name):
         return probe
 
 
-def get_probe(manufacturer, probe_name):
+def get_probe(manufacturer, probe_name, name=None):
     """
     Get probe from ProbeInterface library
 
@@ -81,6 +81,8 @@ def get_probe(manufacturer, probe_name):
         The probe manufacturer (e.g. 'cambridgeneurotech')
     probe_name : str
         The probe name
+    name : str or None
+        Optional name for the probe
 
     Returns
     ----------
@@ -93,5 +95,9 @@ def get_probe(manufacturer, probe_name):
     if probe is None:
         download_probeinterface_file(manufacturer, probe_name)
         probe = get_from_cache(manufacturer, probe_name)
+    if probe.annotations["manufacturer"] == "":
+        probe.annotations["manufacturer"] = manufacturer
+    if name is not None:
+        probe.annotations["name"] = name
 
     return probe

--- a/src/probeinterface/probe.py
+++ b/src/probeinterface/probe.py
@@ -73,7 +73,7 @@ class Probe:
         self.annotate(
             name=name if name is not None else "",
             serial_number=serial_number if serial_number is not None else "",
-            model=model_name if model_name is not None else "",
+            model_name=model_name if model_name is not None else "",
             manufacturer=manufacturer if manufacturer is not None else "",
         )
         # same idea but handle in vector way for contacts
@@ -947,7 +947,9 @@ class Probe:
         except ImportError:
             raise ImportError("to_image() requires the scipy package")
         assert self.ndim == 2
-        assert values.shape == (self.get_contact_count(),), "Bad boy: values must have size equal contact count"
+        assert values.shape == (
+            self.get_contact_count(),
+        ), "Shape mismatch: values must have the same size as contact count"
 
         if xlims is None:
             x0 = np.min(self.contact_positions[:, 0])

--- a/src/probeinterface/probe.py
+++ b/src/probeinterface/probe.py
@@ -15,7 +15,7 @@ class Probe:
 
     """
 
-    def __init__(self, ndim=2, si_units="um"):
+    def __init__(self, ndim=2, si_units="um", name=None, serial_number=None, model_name=None, manufacturer=None):
         """
         Some attributes are protected and have to be set with setters:
           * set_contacts(...)
@@ -27,7 +27,18 @@ class Probe:
             Handles 2D or 3D probe
         si_units: str
             'um', 'mm', 'm'
+        name: str
+            The name of the probe
+        serial_number: str
+            The serial number of the probe
+        model_name: str
+            The model of the probe
+        manufacturer: str
+            The manufacturer of the probe
 
+        Returns
+        -------
+        Probe: instance of Probe
         """
 
         assert ndim in (2, 3)
@@ -58,7 +69,13 @@ class Probe:
 
         # annotation:  a dict that contains all meta information about
         # the probe (name, manufacturor, date of production, ...)
-        self.annotations = dict(name="")
+        self.annotations = dict()
+        self.annotate(
+            name=name if name is not None else "",
+            serial_number=serial_number if serial_number is not None else "",
+            model=model_name if model_name is not None else "",
+            manufacturer=manufacturer if manufacturer is not None else "",
+        )
         # same idea but handle in vector way for contacts
         self.contact_annotations = dict()
 
@@ -90,17 +107,43 @@ class Probe:
     def shank_ids(self):
         return self._shank_ids
 
+    @property
+    def name(self):
+        return self.annotations.get("name", "")
+
+    @property
+    def serial_number(self):
+        return self.annotations.get("serial_number", "")
+
+    @property
+    def model_name(self):
+        return self.annotations.get("model_name", "")
+
+    @property
+    def manufacturer(self):
+        return self.annotations.get("manufacturer", "")
+
     def get_title(self):
         if self.contact_positions is None:
             txt = "Undefined probe"
         else:
             n = self.get_contact_count()
-            name = self.annotations.get("name", "")
-            manufacturer = self.annotations.get("manufacturer", "")
-            if len(name) > 0 or len(manufacturer):
-                txt = f"{manufacturer} - {name} - {n}ch"
+            name = self.name
+            serial_number = self.serial_number
+            model_name = self.model_name
+            manufacturer = self.manufacturer
+            txt = ""
+            if len(name) > 0:
+                txt += f"{name}"
             else:
-                txt = f"Probe - {n}ch"
+                txt += f"Probe"
+            if len(manufacturer) > 0:
+                txt += f" - {manufacturer}"
+            if len(model_name) > 0:
+                txt += f" - {model_name}"
+            if len(serial_number) > 0:
+                txt += f" - {serial_number}"
+            txt += f" - {n}ch"
             if self.shank_ids is not None:
                 num_shank = self.get_shank_count()
                 txt += f" - {num_shank}shanks"

--- a/tests/test_io/test_openephys.py
+++ b/tests/test_io/test_openephys.py
@@ -13,7 +13,7 @@ def test_NP2():
     # NP2
     probe = read_openephys(data_path / "OE_Neuropix-PXI" / "settings.xml")
     assert probe.get_shank_count() == 1
-    assert "2.0 - Single Shank" in probe.annotations["name"]
+    assert "2.0 - Single Shank" in probe.model_name
 
 
 def test_NP1_subset():
@@ -23,7 +23,7 @@ def test_NP1_subset():
     )
 
     assert probe_ap.get_shank_count() == 1
-    assert "1.0" in probe_ap.annotations["name"]
+    assert "1.0" in probe_ap.model_name
     assert len(probe_ap.contact_positions) == 200
 
     probe_lf = read_openephys(
@@ -31,7 +31,7 @@ def test_NP1_subset():
     )
 
     assert probe_lf.get_shank_count() == 1
-    assert "1.0" in probe_lf.annotations["name"]
+    assert "1.0" in probe_lf.model_name
     assert len(probe_lf.contact_positions) == 200
 
     # Not specifying the stream_name should raise an Exception, because both the ProbeA-AP and
@@ -47,7 +47,7 @@ def test_multiple_probes():
     )
 
     assert probeA.get_shank_count() == 1
-    assert "1.0" in probeA.annotations["name"]
+    assert "1.0" in probeA.model_name
 
     probeB = read_openephys(
         data_path / "OE_Neuropix-PXI-multi-probe" / "settings.xml",
@@ -69,10 +69,10 @@ def test_multiple_probes():
 
     assert probeD.get_shank_count() == 1
 
-    assert probeA.annotations["probe_serial_number"] == "17131307831"
-    assert probeB.annotations["probe_serial_number"] == "20403311724"
-    assert probeC.annotations["probe_serial_number"] == "20403311714"
-    assert probeD.annotations["probe_serial_number"] == "21144108671"
+    assert probeA.serial_number == "17131307831"
+    assert probeB.serial_number == "20403311724"
+    assert probeC.serial_number == "20403311714"
+    assert probeD.serial_number == "21144108671"
 
     probeA2 = read_openephys(
         data_path / "OE_Neuropix-PXI-multi-probe" / "settings_2.xml",
@@ -89,7 +89,7 @@ def test_multiple_probes():
     )
 
     assert probeB2.get_shank_count() == 1
-    assert "2.0 - Multishank" in probeB2.annotations["name"]
+    assert "2.0 - Multishank" in probeB2.model_name
 
     ypos = probeB2.contact_positions[:, 1]
     assert np.min(ypos) >= 0
@@ -103,10 +103,11 @@ def test_older_than_06_format():
     )
 
     assert probe.get_shank_count() == 4
-    assert "2.0 - Multishank" in probe.annotations["name"]
+    assert "2.0 - Multishank" in probe.model_name
     ypos = probe.contact_positions[:, 1]
     assert np.min(ypos) >= 0
 
 
 if __name__ == "__main__":
-    test_NP1_subset()
+    test_multiple_probes()
+    test_older_than_06_format()

--- a/tests/test_io/test_spikeglx.py
+++ b/tests/test_io/test_spikeglx.py
@@ -34,12 +34,12 @@ def test_get_saved_channel_indices_from_spikeglx_meta():
 
 def test_NP1():
     probe = read_spikeglx(data_path / "Noise_g0_t0.imec0.ap.meta")
-    assert "1.0" in probe.annotations["name"]
+    assert "1.0" in probe.model_name
 
 
 def test_NP2_1_shanks():
     probe = read_spikeglx(data_path / "p2_g0_t0.imec0.ap.meta")
-    assert "2.0" in probe.annotations["name"]
+    assert "2.0" in probe.model_name
     assert probe.get_shank_count() == 1
 
 
@@ -47,8 +47,8 @@ def test_NP_phase3A():
     # Data provided by rtraghavan
     probe = read_spikeglx(data_path / "phase3a.imec.ap.meta")
 
-    assert probe.annotations["name"] == "Phase3a"
-    assert probe.annotations["manufacturer"] == "IMEC"
+    assert probe.model_name == "Phase3a"
+    assert probe.manufacturer == "IMEC"
     assert probe.annotations["probe_type"] == "Phase3a"
 
     assert probe.ndim == 2
@@ -65,8 +65,8 @@ def test_NP_phase3A():
 def test_NP2_4_shanks():
     probe = read_spikeglx(data_path / "NP2_4_shanks.imec0.ap.meta")
 
-    assert probe.annotations["name"] == "Neuropixels 2.0 - Four Shank"
-    assert probe.annotations["manufacturer"] == "IMEC"
+    assert probe.model_name == "Neuropixels 2.0 - Four Shank"
+    assert probe.manufacturer == "IMEC"
     assert probe.annotations["probe_type"] == 24
 
     assert probe.ndim == 2
@@ -89,8 +89,8 @@ def test_NP2_4_shanks_with_different_electrodes_saved():
     # Data provided by Jennifer Colonell
     probe = read_spikeglx(data_path / "NP2_4_shanks_save_different_electrodes.imec0.ap.meta")
 
-    assert probe.annotations["name"] == "Neuropixels 2.0 - Four Shank"
-    assert probe.annotations["manufacturer"] == "IMEC"
+    assert probe.model_name == "Neuropixels 2.0 - Four Shank"
+    assert probe.manufacturer == "IMEC"
     assert probe.annotations["probe_type"] == 24
 
     assert probe.ndim == 2
@@ -113,7 +113,7 @@ def test_NP2_4_shanks_with_different_electrodes_saved():
 def test_NP1_large_depth_span():
     # Data provided by Tom Bugnon NP1 with large Depth span
     probe = read_spikeglx(data_path / "allan-longcol_g0_t0.imec0.ap.meta")
-    assert "1.0" in probe.annotations["name"]
+    assert "1.0" in probe.model_name
     assert probe.get_shank_count() == 1
     ypos = probe.contact_positions[:, 1]
     assert (np.max(ypos) - np.min(ypos)) > 7600
@@ -123,7 +123,7 @@ def test_NP1_other_example():
     # Data provided by Tom Bugnon NP1
     probe = read_spikeglx(data_path / "doppio-checkerboard_t0.imec0.ap.meta")
     print(probe)
-    assert "1.0" in probe.annotations["name"]
+    assert "1.0" in probe.model_name
     assert probe.get_shank_count() == 1
     ypos = probe.contact_positions[:, 1]
     assert (np.max(ypos) - np.min(ypos)) > 7600
@@ -140,8 +140,8 @@ def test_NPH_long_staggered():
     # Data provided by Nate Dolensek
     probe = read_spikeglx(data_path / "non_human_primate_long_staggered.imec0.ap.meta")
 
-    assert probe.annotations["name"] == "Neuropixels 1.0-NHP - long SOI90 staggered"
-    assert probe.annotations["manufacturer"] == "IMEC"
+    assert probe.model_name == "Neuropixels 1.0-NHP - long SOI90 staggered"
+    assert probe.manufacturer == "IMEC"
     assert probe.annotations["probe_type"] == 1030
 
     assert probe.ndim == 2
@@ -195,8 +195,8 @@ def test_NPH_short_linear_probe_type_0():
     # Data provided by Jonathan A Michaels
     probe = read_spikeglx(data_path / "non_human_primate_short_linear_probe_type_0.meta")
 
-    assert probe.annotations["name"] == "Neuropixels 1.0-NHP - short"
-    assert probe.annotations["manufacturer"] == "IMEC"
+    assert probe.model_name == "Neuropixels 1.0-NHP - short"
+    assert probe.manufacturer == "IMEC"
     assert probe.annotations["probe_type"] == 1015
 
     assert probe.ndim == 2
@@ -246,8 +246,8 @@ def test_ultra_probe():
     # Data provided by Alessio
     probe = read_spikeglx(data_path / "npUltra.meta")
 
-    assert probe.annotations["name"] == "Ultra probe"
-    assert probe.annotations["manufacturer"] == "IMEC"
+    assert probe.model_name == "Ultra probe"
+    assert probe.manufacturer == "IMEC"
     assert probe.annotations["probe_type"] == 1100
 
     # Test contact geometry
@@ -271,4 +271,8 @@ def test_ultra_probe():
 
 def test_CatGT_NP1():
     probe = read_spikeglx(data_path / "catgt.meta")
-    assert "1.0" in probe.annotations["name"]
+    assert "1.0" in probe.model_name
+
+
+if __name__ == "__main__":
+    test_NP1()


### PR DESCRIPTION
This PR adds and unifies the `serial_number`/`model_name`/`manufacturer` annotations.

The `Probe()` constructor can now take these optional argument to automatically populate the annotations. This does not change the probeinteface format specification.

I also unified the serial number retrieval from Open Ephys and SpikeGLX, plus additional metadata.

Fixes #203 