### PR TITLE
`np.in1d` to `np.isin` as the former will be deprecated 

### DIFF
--- a/src/probeinterface/probe.py
+++ b/src/probeinterface/probe.py
@@ -199,7 +199,7 @@ class Probe:
         if isinstance(shapes, str):
             shapes = [shapes] * n
         shapes = np.array(shapes)
-        if not np.all(np.in1d(shapes, _possible_contact_shapes)):
+        if not np.all(np.isin(shapes, _possible_contact_shapes)):
             raise ValueError(f"contacts shape must be in {_possible_contact_shapes}")
         if shapes.shape[0] != n:
             raise ValueError("contacts shape must have same length as posistions")

--- a/tests/test_io/test_io.py
+++ b/tests/test_io/test_io.py
@@ -99,7 +99,7 @@ def test_BIDS_format(tmp_path):
         assert probe_orig.annotations.items() <= probe_read.annotations.items()
         # check if the same attribute lists are present (independent of order)
         assert len(probe_orig.contact_ids) == len(probe_read.contact_ids)
-        assert all(np.in1d(probe_orig.contact_ids, probe_read.contact_ids))
+        assert all(np.isin(probe_orig.contact_ids, probe_read.contact_ids))
 
         # the transformation of contact order between the two probes
         t = np.array(


### PR DESCRIPTION
As in spikeinterface

https://github.com/SpikeInterface/spikeinterface/pull/2002