### PR TITLE
Fix probe special properties setter

### DIFF
--- a/src/probeinterface/probe.py
+++ b/src/probeinterface/probe.py
@@ -125,7 +125,7 @@ class Probe:
 
     @name.setter
     def name(self, value):
-        if value is not None:
+        if value not in [None, ""]:
             self.annotate(name=value)
 
     @property
@@ -134,7 +134,7 @@ class Probe:
 
     @serial_number.setter
     def serial_number(self, value):
-        if value is not None:
+        if value not in [None, ""]:
             self.annotate(serial_number=value)
 
     @property
@@ -143,7 +143,7 @@ class Probe:
 
     @model_name.setter
     def model_name(self, value):
-        if value is not None:
+        if value not in [None, ""]:
             self.annotate(model_name=value)
 
     @property
@@ -152,7 +152,7 @@ class Probe:
 
     @manufacturer.setter
     def manufacturer(self, value):
-        if value is not None:
+        if value not in [None, ""]:
             self.annotate(manufacturer=value)
 
     def get_title(self) -> str:

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -150,6 +150,7 @@ def test_probe_equality_dunder():
     probe2.move([1, 1])
     assert probe2 != probe1
 
+
 def test_set_shanks():
     probe = Probe(ndim=2, si_units="um")
     probe.set_contacts(positions=np.arange(20).reshape(10, 2), shapes="circle", shape_params={"radius": 5})


### PR DESCRIPTION
Right now we have the following behavior:

```python
from probeinterface import Probe

probe = Probe(ndim=2, si_units='um', name="probe_name")
print(probe.annotations)
probe2 = Probe(ndim=2, si_units='um', name=probe.name, serial_number=probe.serial_number)
print(probe2.annotations)

{'name': 'probe_name'}
{'name': 'probe_name', 'serial_number': ''}
```

That is, an artificial empty annotation is created because of the way that the getter and the setter works.

After this PR this is fixed and re-instantiating the probe works as expected:

```python
from probeinterface import Probe

probe = Probe(ndim=2, si_units='um', name="probe_name")
print(probe.annotations)
probe2 = Probe(ndim=2, si_units='um', name=probe.name, serial_number=probe.serial_number)
print(probe2.annotations)

{'name': 'probe_name'}
{'name': 'probe_name'}
```

Another option is to avoid this is to always have those properties in annotations, that is, making the default values of these special attributes (e.g. manufacturer, serial_number, name, etc) the empty string (`''`) instead of None but I kind of feel that is less desirable.

What do you think, @alejo91?