### PR TITLE
Better handling of special annotations when None

### DIFF
--- a/src/probeinterface/probe.py
+++ b/src/probeinterface/probe.py
@@ -177,15 +177,15 @@ class Probe:
             model_name = self.model_name
             manufacturer = self.manufacturer
             txt = ""
-            if len(name) > 0:
+            if name is not None:
                 txt += f"{name}"
             else:
                 txt += f"Probe"
-            if len(manufacturer) > 0:
+            if manufacturer is not None:
                 txt += f" - {manufacturer}"
-            if len(model_name) > 0:
+            if model_name is not None:
                 txt += f" - {model_name}"
-            if len(serial_number) > 0:
+            if serial_number is not None:
                 txt += f" - {serial_number}"
             txt += f" - {n}ch"
             if self.shank_ids is not None:

--- a/src/probeinterface/probe.py
+++ b/src/probeinterface/probe.py
@@ -121,39 +121,51 @@ class Probe:
 
     @property
     def name(self):
-        return self.annotations.get("name", "")
+        return self.annotations.get("name", None)
 
     @name.setter
     def name(self, value):
-        if value not in [None, ""]:
+        if value is not None:
             self.annotate(name=value)
+        else:
+            # we remove the annotation if it exists
+            _ = self.annotations.pop("name", None)
 
     @property
     def serial_number(self):
-        return self.annotations.get("serial_number", "")
+        return self.annotations.get("serial_number", None)
 
     @serial_number.setter
     def serial_number(self, value):
-        if value not in [None, ""]:
+        if value is not None:
             self.annotate(serial_number=value)
+        else:
+            # we remove the annotation if it exists
+            _ = self.annotations.pop("serial_number", None)
 
     @property
     def model_name(self):
-        return self.annotations.get("model_name", "")
+        return self.annotations.get("model_name", None)
 
     @model_name.setter
     def model_name(self, value):
-        if value not in [None, ""]:
+        if value is not None:
             self.annotate(model_name=value)
+        else:
+            # we remove the annotation if it exists
+            _ = self.annotations.pop("model_name", None)
 
     @property
     def manufacturer(self):
-        return self.annotations.get("manufacturer", "")
+        return self.annotations.get("manufacturer", None)
 
     @manufacturer.setter
     def manufacturer(self, value):
-        if value not in [None, ""]:
+        if value is not None:
             self.annotate(manufacturer=value)
+        else:
+            # we remove the annotation if it exists
+            _ = self.annotations.pop("manufacturer", None)
 
     def get_title(self) -> str:
         if self.contact_positions is None:


### PR DESCRIPTION
@h-mayorquin after discussion with Sam we think that this is a better behavior:

- return `None` if the annotation key is not present
- if setting an special annotation to `None`, remove if it's present