### PR TITLE
Update actions version

### DIFF
--- a/.github/workflows/full_tests.yml
+++ b/.github/workflows/full_tests.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
     - name: Install package
@@ -27,7 +27,7 @@ jobs:
     - name: Pytest
       run: |
         pytest --cov=probeinterface --cov-report xml:./coverage.xml
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.8
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: Install Tools


### PR DESCRIPTION
The code coverage actions has been failing. Maybe updating the CI actions to their latest version will help us here. If not, it is useful for maintenance anyway.