### PR TITLE
plot_probe_group -> plot_probegroup

### DIFF
--- a/src/probeinterface/plotting.py
+++ b/src/probeinterface/plotting.py
@@ -183,7 +183,7 @@ def plot_probe(
     return poly, poly_contour
 
 
-def plot_probe_group(probegroup, same_axes: bool = True, **kargs):
+def plot_probegroup(probegroup, same_axes: bool = True, **kargs):
     """Plot all probes from a ProbeGroup
     Can be in an existing set of axes or separate axes.
 
@@ -242,6 +242,22 @@ def plot_probe_group(probegroup, same_axes: bool = True, **kargs):
     kargs["title"] = False
     for i, probe in enumerate(probegroup.probes):
         plot_probe(probe, ax=axs[i], **kargs)
+
+
+def plot_probe_group(probegroup, same_axes: bool = True, **kargs):
+    """
+    This function is deprecated and will be removed in 0.2.23
+    Please use plot_probegroup instead"""
+
+    from warnings import warn
+
+    warn(
+        "`plot_probe_group` is deprecated and will be removed in 2.23. Use plot_probegroup instead",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
+    plot_probegroup(probegroup, same_axes=same_axes, **kargs)
 
 
 def _on_press(probe, event):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,6 +1,6 @@
 from probeinterface import Probe, ProbeGroup
 from probeinterface import generate_dummy_probe, generate_dummy_probe_group
-from probeinterface.plotting import plot_probe, plot_probe_group
+from probeinterface.plotting import plot_probe, plot_probegroup
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -29,18 +29,18 @@ def test_plot_probe():
     plot_probe(probe, show_channel_on_click=True)
 
 
-def test_plot_probe_group():
+def test_plot_probegroup():
     probegroup = generate_dummy_probe_group()
 
-    plot_probe_group(probegroup, same_axes=True, with_contact_id=True)
-    plot_probe_group(probegroup, same_axes=False)
+    plot_probegroup(probegroup, same_axes=True, with_contact_id=True)
+    plot_probegroup(probegroup, same_axes=False)
 
     # 3d
     probegroup_3d = ProbeGroup()
     for probe in probegroup.probes:
         probegroup_3d.add_probe(probe.to_3d())
     probegroup_3d.probes[-1].move([0, 150, -50])
-    plot_probe_group(probegroup_3d, same_axes=True)
+    plot_probegroup(probegroup_3d, same_axes=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -2,6 +2,9 @@ from probeinterface import Probe, ProbeGroup
 from probeinterface import generate_dummy_probe, generate_dummy_probe_group
 from probeinterface.plotting import plot_probe, plot_probegroup
 
+# remove once plot_probe_group is removed
+from probeinterface.plotting import plot_probe_group
+
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -34,6 +37,9 @@ def test_plot_probegroup():
 
     plot_probegroup(probegroup, same_axes=True, with_contact_id=True)
     plot_probegroup(probegroup, same_axes=False)
+
+    # remove when plot_probe_group has been removed
+    plot_probe_group(probegroup)
 
     # 3d
     probegroup_3d = ProbeGroup()


### PR DESCRIPTION
In regards to trying to get more api regularity the object is called a probegroup we don't ever write it as a probe_group. So I would say that to be consistent the plottting function should be plot_probegroup.