### PR TITLE
Fix broken link in ex_11_automatic_wiring.py

### DIFF
--- a/examples/ex_11_automatic_wiring.py
+++ b/examples/ex_11_automatic_wiring.py
@@ -28,7 +28,7 @@ print(probe)
 # Imagine we connect this Neuronexus probe with an Omnetic to an Intan RHD headstage.
 #
 # Using the wiring documentation from these two sites:
-# https://neuronexus.com/wp-content/uploads/2018/09/Wiring_H32.pdf
+# https://www.neuronexus.com/files/wiringconfiguration/Wiring_H32.pdf
 # http://intantech.com/RHD_headstages.html?tabSelect=RHD32ch&yPos=0
 #
 # After a long headache we can figure out the wiring to the device manually and set it


### PR DESCRIPTION
Old link was broken. New link looks like the intended target.