### PR TITLE
Add "packaging" dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 
 dependencies = [
     "numpy",
+    "packaging",
 ]
 
 [project.urls]

--- a/src/probeinterface/io.py
+++ b/src/probeinterface/io.py
@@ -17,7 +17,7 @@ import re
 import warnings
 import json
 from collections import OrderedDict
-from packaging.version import Version, parse
+from packaging.version import parse
 import numpy as np
 from xml.etree import ElementTree
 


### PR DESCRIPTION
There has been a runtime dependency on `packaging` since ef8e7fd, but it's not listed in `pyproject.toml`. This caused an error when I tried to build a conda package for probeinterface.

`packaging.version.Version` was also imported but not used in `io.py`.