### PR TITLE
Add cambridge neurotech adaptor to wiring

### DIFF
--- a/src/probeinterface/wiring.py
+++ b/src/probeinterface/wiring.py
@@ -25,7 +25,8 @@ pathways = {
         24, 23, 25, 22, 26, 21, 27, 20, 28, 19, 29, 18, 30, 17, 31, 16,  0,
         15,  1, 14,  2, 13,  3, 12,  4, 11,  5, 10,  6,  9,  7,  8],
 
-    # nicely given by Aaron Wrong
+    # nicely given by Aaron Wrong;
+    # verified by Zach McKenzie & Chris Halcrow
     'ASSY-77>Adpt.A64-Om32_2x-sm-NN>RHD2164': [
         62, 63, 60, 61, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48,
         32, 33, 34, 35, 37, 36, 39, 41, 43, 45, 47, 38, 42, 44, 46, 40,
@@ -33,11 +34,22 @@ pathways = {
         14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 3, 2, 1, 0],
 
     # done by Samuel Garcia, Alessio Buccino, Jessie Goins for Pierre-Pascal Lenck-Santini
+    # verified by Zach McKenzie & Chris Halcrow
     'ASSY-77>Adpt.A64-Om32_2x-sm-NN>two_RHD2132': [
         47, 32, 46, 33, 34, 45, 35, 44, 36, 43, 37, 42, 38, 41, 39, 40,
         16, 31, 17, 30, 29, 18, 28, 27, 26, 25, 24, 19, 21, 22, 23, 20,
         11, 8, 9, 10, 12, 7, 6, 5, 4, 3, 13, 2, 1, 14, 0, 15,
         55, 56, 54, 57, 53, 58, 52, 59, 51, 60, 50, 61, 62, 49, 63, 48],
+
+    # Done by Zach McKenzie & Chris Halcrow
+    # verified by Samuel Garcia
+    'ASSY-77>Adpt.A64-Om32_2x-sm-cambridge_neurotech>RHD2164': [
+        32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
+        47, 62, 63, 60, 61, 58, 59, 56, 54, 52, 50, 48, 57, 53, 51,
+        49, 55, 9, 15, 13, 11, 7, 14, 12, 10, 8, 6, 5, 4, 3, 2, 1,
+        0, 17, 16, 19, 18, 21, 20, 23, 22, 25, 24, 27, 26, 29, 28,
+        31, 30
+    ],
 
     # from PDF documention of mini-amp-64 page 5
     'cambridgeneurotech_mini-amp-64': [

--- a/src/probeinterface/wiring.py
+++ b/src/probeinterface/wiring.py
@@ -43,7 +43,7 @@ pathways = {
 
     # Done by Zach McKenzie & Chris Halcrow
     # verified by Samuel Garcia
-    'ASSY-77>Adpt.A64-Om32_2x-sm-cambridge_neurotech>RHD2164': [
+    'ASSY-77>Adpt.A64-Om32_2x-sm-cambridgeneurotech>RHD2164': [
         32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
         47, 62, 63, 60, 61, 58, 59, 56, 54, 52, 50, 48, 57, 53, 51,
         49, 55, 9, 15, 13, 11, 7, 14, 12, 10, 8, 6, 5, 4, 3, 2, 1,


### PR DESCRIPTION
@chrishalcrow, could you check my typing for our PR to make sure I put it  in correctly. 

## To-do
* [ ]  share our fixed excel/googlesheet
* [ ] share the intan RH2164 pin map
* [ ] share the adaptor map
* [ ] illustration of the orientation