### PR TITLE
Fix OpenEphys interface issue with multiple probes of which some are disabled

### DIFF
--- a/src/probeinterface/io.py
+++ b/src/probeinterface/io.py
@@ -1699,7 +1699,7 @@ def read_openephys(
         if raise_error:
             raise Exception("NP_PROBE field not found in settings")
         return None
-    
+
     np_probes = [probe for probe in editor.findall("NP_PROBE") if probe.attrib["isEnabled"] == "true"]
     if len(np_probes) == 0:
         if raise_error:

--- a/src/probeinterface/io.py
+++ b/src/probeinterface/io.py
@@ -1699,6 +1699,12 @@ def read_openephys(
         if raise_error:
             raise Exception("NP_PROBE field not found in settings")
         return None
+    
+    np_probes = [probe for probe in editor.findall("NP_PROBE") if probe.attrib["isEnabled"] == "true"]
+    if len(np_probes) == 0:
+        if raise_error:
+            raise Exception("No enabled probes found in settings")
+        return None
 
     # read probes info
     # If STREAMs are not available, probes are sequentially named based on the node id


### PR DESCRIPTION
PR addressing this issue: https://github.com/SpikeInterface/spikeinterface/issues/3539.

Very minimal fix, simply filtering the `XML` nodes corresponding to enabled probes.

Not sure if this is to be tested? I assume there would be the need for custom asset data, have not looked deeply into it.