### PR TITLE
Prepare 0.2.26 release

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -6,6 +6,7 @@ Release notes
 .. toctree::
    :maxdepth: 1
 
+   releases/0.2.26.rst
    releases/0.2.25.rst
    releases/0.2.24.rst
    releases/0.2.23.rst

--- a/doc/releases/0.2.25.rst
+++ b/doc/releases/0.2.25.rst
@@ -1,27 +1,27 @@
-probeinterface 0.2.25
+probeinterface 0.2.26
 ---------------------
 
-Feb, 6th 2025
+Mar, 11th 2025
 
 
 Features
 ^^^^^^^^
 
-* Add cambridge neurotech adaptor to wiring > RHD2164 (#304)
-* Refactor neuropixel in a separate file and generate the NP library (#316)
-* Regenerate ASSY-1-P1 and ASSY-1-P2 probes (#317)
+* Support OneBox processor for Neuropixels-Open Ephys (#327)
+* Wiring pathway for Cambridge A64 adaptor with 2x intan RHD2132 (#306)
+* Add support for NP2020 (Neuropixels 2.0 - Quad Base) (#323)
 
 Bug fixes
 ^^^^^^^^^
 
-* Fix OpenEphys interface issue with multiple probes of which some are disabled (s#308)
-* Update schema to floats for radius, width, height (#296, #297)
+* Fix NP contour from Open Ephys and remove `oe_x_shift`(#323)
 
 Tests
 ^^^^^
 
-* Add json validation to tests (#310)
+* Add test file and test for for NP2 - Quad Base (#328)
 
 Packaging
 ^^^^^^^^^
-* Upper bound to zarr version (#314)
+* Add json schema to core and make jsonschema dependency optional (#326)
+* * Rename `-` to `_` in wiring_references  (#320)

--- a/doc/releases/0.2.26.rst
+++ b/doc/releases/0.2.26.rst
@@ -1,0 +1,27 @@
+probeinterface 0.2.25
+---------------------
+
+Feb, 6th 2025
+
+
+Features
+^^^^^^^^
+
+* Add cambridge neurotech adaptor to wiring > RHD2164 (#304)
+* Refactor neuropixel in a separate file and generate the NP library (#316)
+* Regenerate ASSY-1-P1 and ASSY-1-P2 probes (#317)
+
+Bug fixes
+^^^^^^^^^
+
+* Fix OpenEphys interface issue with multiple probes of which some are disabled (s#308)
+* Update schema to floats for radius, width, height (#296, #297)
+
+Tests
+^^^^^
+
+* Add json validation to tests (#310)
+
+Packaging
+^^^^^^^^^
+* Upper bound to zarr version (#314)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "probeinterface"
-version = "0.2.25"
+version = "0.2.26"
 authors = [
   { name="Samuel Garcia", email="sam.garcia.die@gmail.com" },
   { name="Alessio Buccino", email="alessiop.buccino@gmail.com" },


### PR DESCRIPTION
We added support for OneBox and NP2.0 Quadbase + and important fix to the NP contours from Open Ephys