### PR TITLE
Tests on non-editable package

### DIFF
--- a/.github/workflows/full_tests.yml
+++ b/.github/workflows/full_tests.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install package
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[test]
+        pip install .[test]
     - name: Pytest
       run: |
         pytest --cov=probeinterface --cov-report xml:./coverage.xml


### PR DESCRIPTION
It is a good practice to test as most users would consume the package: in its non-editable version.

