### PR TITLE
Better handling of model_name in neuropixels probe to generate the neuropixels library

### DIFF
--- a/resources/generate_neuropixels_library.py
+++ b/resources/generate_neuropixels_library.py
@@ -80,7 +80,7 @@ def generate_all_npx():
         n = probe.get_contact_count()
 
         title = f"{probe.manufacturer} - {model_name}"
-        title += f"\n{probe.annotations.get('probe_long_name')}"
+        title += f"\n{probe.name}"
         title += f"\n {n}ch"
         if probe.shank_ids is not None:
             num_shank = probe.get_shank_count()

--- a/resources/generate_neuropixels_library.py
+++ b/resources/generate_neuropixels_library.py
@@ -25,19 +25,20 @@ def generate_all_npx():
     probe_part_numbers = probe_features['neuropixels_probes'].keys()
 
 
-    for probe_number in probe_part_numbers:
+    for model_name in probe_part_numbers:
+        print(model_name)
 
-        if probe_number is None:
+        if model_name is None:
             continue
 
-        if probe_number == "NP1110":
+        if model_name == "NP1110":
             # the formula by the imrow table is wrong and more complicated
             continue
 
-        probe_folder = base_folder / probe_number
+        probe_folder = base_folder / model_name
         probe_folder.mkdir(exist_ok=True)
 
-        pt_metadata, _, _ = get_probe_metadata_from_probe_features(probe_features, probe_number)
+        pt_metadata, _, _ = get_probe_metadata_from_probe_features(probe_features, model_name)
 
         num_shank = pt_metadata["num_shanks"]
         contact_per_shank = pt_metadata["cols_per_shank"] * pt_metadata["rows_per_shank"]
@@ -48,7 +49,7 @@ def generate_all_npx():
             elec_ids = np.concatenate([np.arange(contact_per_shank) for i in range(num_shank)])
             shank_ids = np.concatenate([np.zeros(contact_per_shank) + i for i in range(num_shank)])
 
-        probe = _make_npx_probe_from_description(pt_metadata, elec_ids, shank_ids)
+        probe = _make_npx_probe_from_description(pt_metadata, model_name, elec_ids, shank_ids)
 
         # ploting
         fig, axs = plt.subplots(ncols=2)
@@ -78,8 +79,8 @@ def generate_all_npx():
 
         n = probe.get_contact_count()
 
-        title = probe_number
-        title += f"\n{probe.manufacturer} - {probe.model_name}"
+        title = f"{probe.manufacturer} - {model_name}"
+        title += f"\n{probe.annotations.get('probe_long_name')}"
         title += f"\n {n}ch"
         if probe.shank_ids is not None:
             num_shank = probe.get_shank_count()
@@ -90,9 +91,11 @@ def generate_all_npx():
 
         # plt.show()
 
-        fig.savefig(probe_folder / f"{probe_number}.png")
+        fig.savefig(probe_folder / f"{model_name}.png")
 
-        write_probeinterface(probe_folder / f"{probe_number}.json", probe)
+        write_probeinterface(probe_folder / f"{model_name}.json", probe)
+
+        # plt.show()
 
         plt.close(fig)
 

--- a/resources/generate_neuropixels_library.py
+++ b/resources/generate_neuropixels_library.py
@@ -80,7 +80,7 @@ def generate_all_npx():
         n = probe.get_contact_count()
 
         title = f"{probe.manufacturer} - {model_name}"
-        title += f"\n{probe.name}"
+        title += f"\n{probe.description}"
         title += f"\n {n}ch"
         if probe.shank_ids is not None:
             num_shank = probe.get_shank_count()

--- a/src/probeinterface/library.py
+++ b/src/probeinterface/library.py
@@ -34,7 +34,7 @@ def download_probeinterface_file(manufacturer: str, probe_name: str):
 
     Parameters
     ----------
-    manufacturer : "cambridgeneurotech" | "neuronexus"
+    manufacturer : "cambridgeneurotech" | "neuronexus" | "plexon" | "imec" | "sinaps"
         The probe manufacturer
     probe_name : str (see probeinterface_libary for options)
         The probe name
@@ -53,7 +53,7 @@ def get_from_cache(manufacturer: str, probe_name: str) -> Optional["Probe"]:
 
     Parameters
     ----------
-    manufacturer : "cambridgeneurotech" | "neuronexus"
+    manufacturer : "cambridgeneurotech" | "neuronexus" | "plexon" | "imec" | "sinaps"
         The probe manufacturer
     probe_name : str (see probeinterface_libary for options)
         The probe name
@@ -80,7 +80,7 @@ def get_probe(manufacturer: str, probe_name: str, name: Optional[str] = None) ->
 
     Parameters
     ----------
-    manufacturer : "cambridgeneurotech" | "neuronexus"
+    manufacturer : "cambridgeneurotech" | "neuronexus" | "plexon" | "imec" | "sinaps"
         The probe manufacturer
     probe_name : str (see probeinterface_libary for options)
         The probe name

--- a/src/probeinterface/neuropixels_tools.py
+++ b/src/probeinterface/neuropixels_tools.py
@@ -257,8 +257,8 @@ def _make_npx_probe_from_description(probe_description, elec_ids, shank_ids, mux
     )
 
     stagger = np.mod(y_idx + 1, 2) * raw_stagger
-    x_pos = x_idx * x_pitch + stagger
-    y_pos = y_idx * y_pitch
+    x_pos = (x_idx * x_pitch + stagger).astype("float64")
+    y_pos = (y_idx * y_pitch).astype("float64")
 
     # if probe_description["shank_number"] > 1:
     if shank_ids is not None:

--- a/src/probeinterface/neuropixels_tools.py
+++ b/src/probeinterface/neuropixels_tools.py
@@ -89,23 +89,6 @@ imro_field_to_pi_field = {
     "bankB": "bankB",
 }
 
-# Map from ProbeInterface to ProbeTable naming conventions
-# @Chris : is this necessary ?
-# pi_to_pt_names = {
-#     "x_pitch": "electrode_pitch_horz_um",
-#     "y_pitch": "electrode_pitch_vert_um",
-#     "contact_width": "electrode_size_horz_direction_um",
-#     "shank_pitch": "shank_pitch_um",
-#     "shank_number": "num_shanks",
-#     "ncols_per_shank": "cols_per_shank",
-#     "nrows_per_shank": "rows_per_shank",
-#     "adc_bit_depth": "adc_bit_depth",
-#     "model_name": "description",
-#     "num_readout_channels": "num_readout_channels",
-#     "shank_width_um": "shank_width_um",
-#     "tip_length_um": "tip_length_um",
-# }
-
 
 def get_probe_length(probe_part_number: str) -> int:
     """

--- a/src/probeinterface/neuropixels_tools.py
+++ b/src/probeinterface/neuropixels_tools.py
@@ -241,10 +241,8 @@ def read_imro(file_path: Union[str, Path]) -> Probe:
     return _read_imro_string(imro_str, imDatPrb_pn)
 
 
-def _make_npx_probe_from_description(probe_description, elec_ids, shank_ids, mux_table=None) -> Probe:
+def _make_npx_probe_from_description(probe_description, model_name, elec_ids, shank_ids, mux_table=None) -> Probe:
     # used by _read_imro_string and for generating the NP library
-
-    model_name = probe_description["description"]
 
     # compute position
     y_idx, x_idx = np.divmod(elec_ids, probe_description["cols_per_shank"])
@@ -273,7 +271,7 @@ def _make_npx_probe_from_description(probe_description, elec_ids, shank_ids, mux
     positions = np.stack((x_pos, y_pos), axis=1)
 
     # construct Probe object
-    probe = Probe(ndim=2, si_units="um", model_name=model_name, manufacturer="IMEC")
+    probe = Probe(ndim=2, si_units="um", model_name=model_name, manufacturer="imec", name=probe_description["description"])
     probe.set_contacts(
         positions=positions,
         shapes="square",
@@ -282,6 +280,7 @@ def _make_npx_probe_from_description(probe_description, elec_ids, shank_ids, mux
     )
 
     probe.set_contact_ids(contact_ids)
+
 
     # Add planar contour
     polygon = np.array(
@@ -386,7 +385,7 @@ def _read_imro_string(imro_str: str, imDatPrb_pn: Optional[str] = None) -> Probe
     else:
         shank_ids = None
 
-    probe = _make_npx_probe_from_description(pt_metadata, elec_ids, shank_ids, mux_table)
+    probe = _make_npx_probe_from_description(pt_metadata, imDatPrb_pn, elec_ids, shank_ids, mux_table)
 
     # scalar annotations
     probe.annotate(
@@ -1056,7 +1055,7 @@ def read_openephys(
         if elec_ids is not None:
             elec_ids = np.array(elec_ids)[chans_saved]
 
-    probe = _make_npx_probe_from_description(pt_metadata, elec_ids, shank_ids=shank_ids, mux_table=mux_table)
+    probe = _make_npx_probe_from_description(pt_metadata, probe_part_number, elec_ids, shank_ids=shank_ids, mux_table=mux_table)
     probe.serial_number = np_probe_info["serial_number"]
 
     probe.annotate(

--- a/src/probeinterface/neuropixels_tools.py
+++ b/src/probeinterface/neuropixels_tools.py
@@ -90,20 +90,21 @@ imro_field_to_pi_field = {
 }
 
 # Map from ProbeInterface to ProbeTable naming conventions
-pi_to_pt_names = {
-    "x_pitch": "electrode_pitch_horz_um",
-    "y_pitch": "electrode_pitch_vert_um",
-    "contact_width": "electrode_size_horz_direction_um",
-    "shank_pitch": "shank_pitch_um",
-    "shank_number": "num_shanks",
-    "ncols_per_shank": "cols_per_shank",
-    "nrows_per_shank": "rows_per_shank",
-    "adc_bit_depth": "adc_bit_depth",
-    "model_name": "description",
-    "num_readout_channels": "num_readout_channels",
-    "shank_width_um": "shank_width_um",
-    "tip_length_um": "tip_length_um",
-}
+# @Chris : is this necessary ?
+# pi_to_pt_names = {
+#     "x_pitch": "electrode_pitch_horz_um",
+#     "y_pitch": "electrode_pitch_vert_um",
+#     "contact_width": "electrode_size_horz_direction_um",
+#     "shank_pitch": "shank_pitch_um",
+#     "shank_number": "num_shanks",
+#     "ncols_per_shank": "cols_per_shank",
+#     "nrows_per_shank": "rows_per_shank",
+#     "adc_bit_depth": "adc_bit_depth",
+#     "model_name": "description",
+#     "num_readout_channels": "num_readout_channels",
+#     "shank_width_um": "shank_width_um",
+#     "tip_length_um": "tip_length_um",
+# }
 
 
 def get_probe_length(probe_part_number: str) -> int:
@@ -271,9 +272,8 @@ def _make_npx_probe_from_description(probe_description, model_name, elec_ids, sh
     positions = np.stack((x_pos, y_pos), axis=1)
 
     # construct Probe object
-    probe = Probe(
-        ndim=2, si_units="um", model_name=model_name, manufacturer="imec", name=probe_description["description"]
-    )
+    probe = Probe(ndim=2, si_units="um", model_name=model_name, manufacturer="imec")
+    probe.description = probe_description["description"]
     probe.set_contacts(
         positions=positions,
         shapes="square",
@@ -905,14 +905,12 @@ def read_openephys(
         )
         num_shanks = pt_metadata["num_shanks"]
 
-        model_name = pt_metadata.get("description")
-        if model_name is None:
-            model_name = "Unknown"
+        description = pt_metadata.get("description")
 
         elec_ids = []
         for i, pos in enumerate(positions):
             # Do not calculate contact ids if the model name is not known
-            if model_name == "Unknown":
+            if description is None:
                 elec_ids = None
                 break
 
@@ -1060,6 +1058,7 @@ def read_openephys(
         pt_metadata, probe_part_number, elec_ids, shank_ids=shank_ids, mux_table=mux_table
     )
     probe.serial_number = np_probe_info["serial_number"]
+    probe.name = np_probe_info["name"]
 
     probe.annotate(
         part_number=np_probe_info["part_number"],

--- a/src/probeinterface/probe.py
+++ b/src/probeinterface/probe.py
@@ -201,6 +201,18 @@ class Probe:
             # we remove the annotation if it exists
             _ = self.annotations.pop("manufacturer", None)
 
+    @property
+    def description(self):
+        return self.annotations.get("description", None)
+
+    @description.setter
+    def description(self, value):
+        if value is not None:
+            self.annotate(description=value)
+        else:
+            # we remove the annotation if it exists
+            _ = self.annotations.pop("description", None)
+
     def get_title(self) -> str:
         if self.contact_positions is None:
             txt = "Undefined probe"

--- a/tests/test_io/test_openephys.py
+++ b/tests/test_io/test_openephys.py
@@ -85,7 +85,7 @@ def test_NP1_subset():
     validate_probe_dict(probe_dict)
 
     assert probe_ap.get_shank_count() == 1
-    assert "1.0" in probe_ap.model_name
+    assert "1.0" in probe_ap.name
     assert probe_ap.get_contact_count() == 200
 
     probe_lf = read_openephys(data_path / "OE_Neuropix-PXI-subset" / "settings.xml", stream_name="ProbeA-LFP")
@@ -93,7 +93,7 @@ def test_NP1_subset():
     validate_probe_dict(probe_dict)
 
     assert probe_lf.get_shank_count() == 1
-    assert "1.0" in probe_lf.model_name
+    assert "1.0" in probe_lf.name
     assert len(probe_lf.contact_positions) == 200
 
     # Not specifying the stream_name should raise an Exception, because both the ProbeA-AP and
@@ -109,7 +109,7 @@ def test_multiple_probes():
     validate_probe_dict(probe_dict)
 
     assert probeA.get_shank_count() == 1
-    assert "1.0" in probeA.model_name
+    assert "1.0" in probeA.name
 
     probeB = read_openephys(
         data_path / "OE_Neuropix-PXI-multi-probe" / "settings.xml",

--- a/tests/test_io/test_openephys.py
+++ b/tests/test_io/test_openephys.py
@@ -85,7 +85,7 @@ def test_NP1_subset():
     validate_probe_dict(probe_dict)
 
     assert probe_ap.get_shank_count() == 1
-    assert "1.0" in probe_ap.name
+    assert "1.0" in probe_ap.description
     assert probe_ap.get_contact_count() == 200
 
     probe_lf = read_openephys(data_path / "OE_Neuropix-PXI-subset" / "settings.xml", stream_name="ProbeA-LFP")
@@ -93,7 +93,7 @@ def test_NP1_subset():
     validate_probe_dict(probe_dict)
 
     assert probe_lf.get_shank_count() == 1
-    assert "1.0" in probe_lf.name
+    assert "1.0" in probe_lf.description
     assert len(probe_lf.contact_positions) == 200
 
     # Not specifying the stream_name should raise an Exception, because both the ProbeA-AP and
@@ -109,7 +109,7 @@ def test_multiple_probes():
     validate_probe_dict(probe_dict)
 
     assert probeA.get_shank_count() == 1
-    assert "1.0" in probeA.name
+    assert "1.0" in probeA.description
 
     probeB = read_openephys(
         data_path / "OE_Neuropix-PXI-multi-probe" / "settings.xml",

--- a/tests/test_io/test_spikeglx.py
+++ b/tests/test_io/test_spikeglx.py
@@ -43,14 +43,14 @@ def test_get_saved_channel_indices_from_spikeglx_meta():
 
 def test_NP1():
     probe = read_spikeglx(data_path / "Noise_g0_t0.imec0.ap.meta")
-    assert "1.0" in probe.model_name
+    assert "1.0" in probe.name
 
 
 def test_NP_phase3A():
     # Data provided by rtraghavan
     probe = read_spikeglx(data_path / "phase3a.imec.ap.meta")
 
-    assert probe.manufacturer == "IMEC"
+    assert probe.manufacturer == "imec"
 
     assert probe.ndim == 2
     assert probe.get_shank_count() == 1
@@ -66,14 +66,14 @@ def test_NP_phase3A():
 
 def test_NP2_1_shanks():
     probe = read_spikeglx(data_path / "p2_g0_t0.imec0.ap.meta")
-    assert "2.0" in probe.model_name
+    assert "2.0" in probe.name
     assert probe.get_shank_count() == 1
 
 
 def test_NP2_4_shanks():
     probe = read_spikeglx(data_path / "NP2_4_shanks.imec0.ap.meta")
 
-    assert probe.manufacturer == "IMEC"
+    assert probe.manufacturer == "imec"
 
     assert probe.ndim == 2
     assert probe.get_shank_count() == 4
@@ -95,7 +95,7 @@ def test_NP2_2013_all():
     # Data provided by Jennifer Colonell
     probe = read_spikeglx(data_path / "NP2_2013_all_channels.imec0.ap.meta")
 
-    assert probe.manufacturer == "IMEC"
+    assert probe.manufacturer == "imec"
 
     assert probe.ndim == 2
     # all channels are from the first shank
@@ -118,7 +118,7 @@ def test_NP2_2013_subset():
     # Data provided by Jennifer Colonell
     probe = read_spikeglx(data_path / "NP2_2013_subset_channels.imec0.ap.meta")
 
-    assert probe.manufacturer == "IMEC"
+    assert probe.manufacturer == "imec"
 
     assert probe.ndim == 2
     # all channels are from the first shank
@@ -141,7 +141,7 @@ def test_NP2_4_shanks_with_different_electrodes_saved():
     # Data provided by Jennifer Colonell
     probe = read_spikeglx(data_path / "NP2_4_shanks_save_different_electrodes.imec0.ap.meta")
 
-    assert probe.manufacturer == "IMEC"
+    assert probe.manufacturer == "imec"
 
     assert probe.ndim == 2
     assert probe.get_shank_count() == 4
@@ -163,7 +163,7 @@ def test_NP2_4_shanks_with_different_electrodes_saved():
 def test_NP1_large_depth_span():
     # Data provided by Tom Bugnon NP1 with large Depth span
     probe = read_spikeglx(data_path / "allan-longcol_g0_t0.imec0.ap.meta")
-    assert "1.0" in probe.model_name
+    assert "1.0" in probe.name
     assert probe.get_shank_count() == 1
     ypos = probe.contact_positions[:, 1]
     assert (np.max(ypos) - np.min(ypos)) > 7600
@@ -173,7 +173,7 @@ def test_NP1_other_example():
     # Data provided by Tom Bugnon NP1
     probe = read_spikeglx(data_path / "doppio-checkerboard_t0.imec0.ap.meta")
     print(probe)
-    assert "1.0" in probe.model_name
+    assert "1.0" in probe.name
     assert probe.get_shank_count() == 1
     ypos = probe.contact_positions[:, 1]
     assert (np.max(ypos) - np.min(ypos)) > 7600
@@ -191,7 +191,7 @@ def test_NPH_long_staggered():
     # Data provided by Nate Dolensek
     probe = read_spikeglx(data_path / "non_human_primate_long_staggered.imec0.ap.meta")
 
-    assert probe.manufacturer == "IMEC"
+    assert probe.manufacturer == "imec"
 
     assert probe.ndim == 2
     assert probe.get_shank_count() == 1
@@ -245,7 +245,7 @@ def test_NPH_short_linear_probe_type_0():
     # Data provided by Jonathan A Michaels
     probe = read_spikeglx(data_path / "non_human_primate_short_linear_probe_type_0.meta")
 
-    assert probe.manufacturer == "IMEC"
+    assert probe.manufacturer == "imec"
 
     assert probe.ndim == 2
     assert probe.get_shank_count() == 1
@@ -293,7 +293,7 @@ def test_ultra_probe():
     # Data provided by Alessio
     probe = read_spikeglx(data_path / "npUltra.meta")
 
-    assert probe.manufacturer == "IMEC"
+    assert probe.manufacturer == "imec"
 
     # Test contact geometry
     contact_width = 5.0
@@ -317,7 +317,7 @@ def test_ultra_probe():
 
 def test_CatGT_NP1():
     probe = read_spikeglx(data_path / "catgt.meta")
-    assert "1.0" in probe.model_name
+    assert "1.0" in probe.name
 
 
 def test_snsGeomMap():

--- a/tests/test_io/test_spikeglx.py
+++ b/tests/test_io/test_spikeglx.py
@@ -43,7 +43,7 @@ def test_get_saved_channel_indices_from_spikeglx_meta():
 
 def test_NP1():
     probe = read_spikeglx(data_path / "Noise_g0_t0.imec0.ap.meta")
-    assert "1.0" in probe.name
+    assert "1.0" in probe.description
 
 
 def test_NP_phase3A():
@@ -66,7 +66,7 @@ def test_NP_phase3A():
 
 def test_NP2_1_shanks():
     probe = read_spikeglx(data_path / "p2_g0_t0.imec0.ap.meta")
-    assert "2.0" in probe.name
+    assert "2.0" in probe.description
     assert probe.get_shank_count() == 1
 
 
@@ -163,7 +163,7 @@ def test_NP2_4_shanks_with_different_electrodes_saved():
 def test_NP1_large_depth_span():
     # Data provided by Tom Bugnon NP1 with large Depth span
     probe = read_spikeglx(data_path / "allan-longcol_g0_t0.imec0.ap.meta")
-    assert "1.0" in probe.name
+    assert "1.0" in probe.description
     assert probe.get_shank_count() == 1
     ypos = probe.contact_positions[:, 1]
     assert (np.max(ypos) - np.min(ypos)) > 7600
@@ -173,7 +173,7 @@ def test_NP1_other_example():
     # Data provided by Tom Bugnon NP1
     probe = read_spikeglx(data_path / "doppio-checkerboard_t0.imec0.ap.meta")
     print(probe)
-    assert "1.0" in probe.name
+    assert "1.0" in probe.description
     assert probe.get_shank_count() == 1
     ypos = probe.contact_positions[:, 1]
     assert (np.max(ypos) - np.min(ypos)) > 7600
@@ -317,7 +317,7 @@ def test_ultra_probe():
 
 def test_CatGT_NP1():
     probe = read_spikeglx(data_path / "catgt.meta")
-    assert "1.0" in probe.name
+    assert "1.0" in probe.description
 
 
 def test_snsGeomMap():


### PR DESCRIPTION
Better handling of model_name in neuropixels probe to generate the neuropixels library.

Now for instance:
`model_name = "NP1010"`
end 
`name = "Neuropixels 1.0 NHP short staggered probe with cap"`

This is more consistent <with the probeinterface_library.

Also change IMEC to imec.

Also handle float for positions


