### PR TITLE
Add dense-array-base representation handle to ProbeGroup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ cov.xml
 .DS_Store
 
 uv.lock
+.codex
 
 # libraries
 **/neuropixels_library_generated

--- a/src/probeinterface/probegroup.py
+++ b/src/probeinterface/probegroup.py
@@ -13,6 +13,11 @@ class ProbeGroup:
 
     def __init__(self):
         self.probes = []
+        self._contact_vector = None
+
+    @property
+    def contact_vector(self):
+        return self._contact_vector
 
     def add_probe(self, probe: Probe):
         """
@@ -29,6 +34,7 @@ class ProbeGroup:
 
         self.probes.append(probe)
         probe._probe_group = self
+        self._contact_vector = None
 
     def _check_compatible(self, probe: Probe):
         if probe._probe_group is not None:
@@ -61,6 +67,57 @@ class ProbeGroup:
         """
         n = sum(probe.get_contact_count() for probe in self.probes)
         return n
+
+    def _build_contact_vector(self) -> None:
+        if len(self.probes) == 0:
+            raise ValueError("Cannot build a contact_vector for an empty ProbeGroup")
+
+        has_shank_ids = any(probe.shank_ids is not None for probe in self.probes)
+        has_contact_sides = any(probe.contact_sides is not None for probe in self.probes)
+
+        dtype = [("probe_index", "int64"), ("x", "float64"), ("y", "float64")]
+        if self.ndim == 3:
+            dtype.append(("z", "float64"))
+        if has_shank_ids:
+            dtype.append(("shank_ids", "U64"))
+        if has_contact_sides:
+            dtype.append(("contact_sides", "U8"))
+
+        channel_index_parts = []
+        contact_vector_parts = []
+        for probe_index, probe in enumerate(self.probes):
+            device_channel_indices = probe.device_channel_indices
+            if device_channel_indices is None:
+                continue
+
+            device_channel_indices = np.asarray(device_channel_indices)
+            connected = device_channel_indices >= 0
+            if not np.any(connected):
+                continue
+
+            probe_vector = np.zeros(np.sum(connected), dtype=dtype)
+            probe_vector["probe_index"] = probe_index
+            probe_vector["x"] = probe.contact_positions[connected, 0]
+            probe_vector["y"] = probe.contact_positions[connected, 1]
+            if self.ndim == 3:
+                probe_vector["z"] = probe.contact_positions[connected, 2]
+            if has_shank_ids and probe.shank_ids is not None:
+                probe_vector["shank_ids"] = probe.shank_ids[connected]
+            if has_contact_sides and probe.contact_sides is not None:
+                probe_vector["contact_sides"] = probe.contact_sides[connected]
+
+            channel_index_parts.append(device_channel_indices[connected])
+            contact_vector_parts.append(probe_vector)
+
+        if len(contact_vector_parts) == 0:
+            raise ValueError("contact_vector requires at least one wired contact")
+
+        channel_indices = np.concatenate(channel_index_parts, axis=0)
+        contact_vector = np.concatenate(contact_vector_parts, axis=0)
+        order = np.argsort(channel_indices, kind="stable")
+        contact_vector = contact_vector[order]
+        contact_vector.setflags(write=False)
+        self._contact_vector = contact_vector
 
     def to_numpy(self, complete: bool = False) -> np.ndarray:
         """
@@ -281,6 +338,7 @@ class ProbeGroup:
         probe_ids = generate_unique_ids(*args, **kwargs).astype(str)
         for pid, probe in enumerate(self.probes):
             probe.annotate(probe_id=probe_ids[pid])
+        self._contact_vector = None
 
     def auto_generate_contact_ids(self, *args, **kwargs):
         """
@@ -303,3 +361,4 @@ class ProbeGroup:
         for probe in self.probes:
             el_ids, contact_ids = np.split(contact_ids, [probe.get_contact_count()])
             probe.set_contact_ids(el_ids)
+        self._contact_vector = None

--- a/src/probeinterface/probegroup.py
+++ b/src/probeinterface/probegroup.py
@@ -20,15 +20,35 @@ class ProbeGroup:
         """
         Channel-ordered dense view of the probegroup, built lazily on first access.
 
-        Private by convention: this handle is intended for integration with SpikeInterface
-        that needs a channel-ordered view for recording-facing queries. 
-        
-        Fields and dtype may evolve with consumer requirements, so user code should not depend on it directly. For stable probegroup state, use
-        the public `get_global_*` methods.
+        Private by convention: this handle is intended for integration with SpikeInterface,
+        which needs a channel-ordered view for recording-facing queries. Fields and dtype
+        may evolve with consumer requirements, so user code should not depend on it directly.
+        For stable probegroup state, use the public `get_global_*` methods.
 
-        The cache is invalidated on probegroup-level mutations (`add_probe`,
-        `set_global_device_channel_indices`, `auto_generate_*`). Probe-level mutations
-        (for example `probe.move`, `probe.set_contact_ids`, direct writes to
+        Invariants
+        ----------
+        - Ordering: rows are sorted ascending by `device_channel_indices` using a stable
+          sort. Ties preserve per-probe insertion order.
+        - Row count: one row per *connected* contact (`device_channel_indices >= 0`).
+          `len(self._contact_vector)` is generally smaller than `self.get_contact_count()`
+          when the probegroup has unwired contacts. This matches SpikeInterface's
+          pre-migration `contact_vector` convention.
+        - Dtype: includes `probe_index`, `x`, `y`, and `z` if `ndim == 3`. Optional fields
+          `shank_ids` and `contact_sides` appear only when at least one probe in the group
+          defines them. Consumers must guard field access accordingly.
+        - Raises `ValueError` on empty probegroups and on probegroups with no wired
+          contacts. Callers that may hold unwired probegroups should check wiring before
+          reading this attribute.
+        - The returned array is marked read-only (`setflags(write=False)`). The cache
+          object may be replaced on invalidation, so a stored reference is not guaranteed
+          to survive probegroup mutations.
+
+        Cache invalidation
+        ------------------
+        The cache is cleared on probegroup-level mutations (`add_probe`,
+        `set_global_device_channel_indices`, `auto_generate_probe_ids`,
+        `auto_generate_contact_ids`) and rebuilt on next access. Probe-level mutations
+        (for example `probe.move`, `probe.set_contact_ids`, or direct writes to
         `probe._contact_positions`) do NOT invalidate the cache by design: keeping
         `ProbeGroup` unaware of `Probe` mutations avoids container/contained coupling.
         Consumers that mutate a probe after attaching its probegroup must call
@@ -88,6 +108,15 @@ class ProbeGroup:
         return n
 
     def _build_contact_vector(self) -> None:
+        """
+        Build the channel-ordered `_contact_vector` cache.
+
+        The cache has one row per *connected* contact (`device_channel_indices >= 0`),
+        sorted ascending by `device_channel_indices`. `self._contact_vector.size` may
+        therefore be smaller than `self.get_contact_count()` when the probegroup has
+        unwired contacts; that is the intended semantics, matching SpikeInterface's
+        pre-migration `contact_vector` convention.
+        """
         if len(self.probes) == 0:
             raise ValueError("Cannot build a contact_vector for an empty ProbeGroup")
 

--- a/src/probeinterface/probegroup.py
+++ b/src/probeinterface/probegroup.py
@@ -13,50 +13,6 @@ class ProbeGroup:
 
     def __init__(self):
         self.probes = []
-        self._contact_vector_cache = None
-
-    @property
-    def _contact_vector(self):
-        """
-        Channel-ordered dense view of the probegroup, built lazily on first access.
-
-        Private by convention: this handle is intended for integration with SpikeInterface,
-        which needs a channel-ordered view for recording-facing queries. Fields and dtype
-        may evolve with consumer requirements, so user code should not depend on it directly.
-        For stable probegroup state, use the public `get_global_*` methods.
-
-        Invariants
-        ----------
-        - Ordering: rows are sorted ascending by `device_channel_indices` using a stable
-          sort. Ties preserve per-probe insertion order.
-        - Row count: one row per *connected* contact (`device_channel_indices >= 0`).
-          `len(self._contact_vector)` is generally smaller than `self.get_contact_count()`
-          when the probegroup has unwired contacts. This matches SpikeInterface's
-          pre-migration `contact_vector` convention.
-        - Dtype: includes `probe_index`, `x`, `y`, and `z` if `ndim == 3`. Optional fields
-          `shank_ids` and `contact_sides` appear only when at least one probe in the group
-          defines them. Consumers must guard field access accordingly.
-        - Raises `ValueError` on empty probegroups and on probegroups with no wired
-          contacts. Callers that may hold unwired probegroups should check wiring before
-          reading this attribute.
-        - The returned array is marked read-only (`setflags(write=False)`). The cache
-          object may be replaced on invalidation, so a stored reference is not guaranteed
-          to survive probegroup mutations.
-
-        Cache invalidation
-        ------------------
-        The cache is cleared on probegroup-level mutations (`add_probe`,
-        `set_global_device_channel_indices`, `auto_generate_probe_ids`,
-        `auto_generate_contact_ids`) and rebuilt on next access. Probe-level mutations
-        (for example `probe.move`, `probe.set_contact_ids`, or direct writes to
-        `probe._contact_positions`) do NOT invalidate the cache by design: keeping
-        `ProbeGroup` unaware of `Probe` mutations avoids container/contained coupling.
-        Consumers that mutate a probe after attaching its probegroup must call
-        `_build_contact_vector()` explicitly to refresh.
-        """
-        if self._contact_vector_cache is None:
-            self._build_contact_vector()
-        return self._contact_vector_cache
 
     def add_probe(self, probe: Probe) -> None:
         """
@@ -73,7 +29,6 @@ class ProbeGroup:
 
         self.probes.append(probe)
         probe._probe_group = self
-        self._contact_vector_cache = None
 
     def _check_compatible(self, probe: Probe) -> None:
         if probe._probe_group is not None:
@@ -123,15 +78,32 @@ class ProbeGroup:
         n = sum(probe.get_contact_count() for probe in self.probes)
         return n
 
-    def _build_contact_vector(self) -> None:
+    def _build_contact_vector(self) -> np.ndarray:
         """
-        Build the channel-ordered `_contact_vector` cache.
+        Return the channel-ordered dense view of the probegroup, computed fresh.
 
-        The cache has one row per *connected* contact (`device_channel_indices >= 0`),
-        sorted ascending by `device_channel_indices`. `self._contact_vector.size` may
-        therefore be smaller than `self.get_contact_count()` when the probegroup has
-        unwired contacts; that is the intended semantics, matching SpikeInterface's
-        pre-migration `contact_vector` convention.
+        Private by convention: this method is intended for integration with SpikeInterface,
+        which needs a channel-ordered view for recording-facing queries. Fields and dtype
+        may evolve with consumer requirements, so user code should not depend on it directly.
+        For stable probegroup state, use the public `get_global_*` methods.
+
+        Invariants
+        ----------
+        - Ordering: rows are sorted ascending by `device_channel_indices` using a stable
+          sort. Ties preserve per-probe insertion order.
+        - Row count: one row per *connected* contact (`device_channel_indices >= 0`).
+          The returned size is generally smaller than `self.get_contact_count()` when the
+          probegroup has unwired contacts. This matches SpikeInterface's pre-migration
+          `contact_vector` convention.
+        - Dtype: includes `probe_index`, `x`, `y`, and `z` if `ndim == 3`. Optional fields
+          `shank_ids` and `contact_sides` appear only when at least one probe in the group
+          defines them. Consumers must guard field access accordingly.
+        - Raises `ValueError` on empty probegroups and on probegroups with no wired
+          contacts.
+
+        This method builds a fresh array on every call. It is not cached. Consumers that
+        need to call it repeatedly in a hot loop should cache the result at the call site,
+        where the lifetime and invalidation story are local.
         """
         if len(self.probes) == 0:
             raise ValueError("Cannot build a contact_vector for an empty ProbeGroup")
@@ -179,9 +151,7 @@ class ProbeGroup:
         channel_indices = np.concatenate(channel_index_parts, axis=0)
         contact_vector = np.concatenate(contact_vector_parts, axis=0)
         order = np.argsort(channel_indices, kind="stable")
-        contact_vector = contact_vector[order]
-        contact_vector.setflags(write=False)
-        self._contact_vector_cache = contact_vector
+        return contact_vector[order]
 
     def to_numpy(self, complete: bool = False) -> np.ndarray:
         """
@@ -358,9 +328,6 @@ class ProbeGroup:
             probe.set_device_channel_indices(channels[ind : ind + n])
             ind += n
 
-        # invalidate the cache since channel ordering changed
-        self._contact_vector_cache = None
-
     def get_global_contact_ids(self) -> np.ndarray:
         """
         Gets all contact ids concatenated across probes
@@ -484,7 +451,6 @@ class ProbeGroup:
         probe_ids = generate_unique_ids(*args, **kwargs).astype(str)
         for pid, probe in enumerate(self.probes):
             probe.annotate(probe_id=probe_ids[pid])
-        self._contact_vector_cache = None
 
     def auto_generate_contact_ids(self, *args, **kwargs) -> None:
         """
@@ -507,4 +473,3 @@ class ProbeGroup:
         for probe in self.probes:
             el_ids, contact_ids = np.split(contact_ids, [probe.get_contact_count()])
             probe.set_contact_ids(el_ids)
-        self._contact_vector_cache = None

--- a/src/probeinterface/probegroup.py
+++ b/src/probeinterface/probegroup.py
@@ -17,6 +17,8 @@ class ProbeGroup:
 
     @property
     def contact_vector(self):
+        if self._contact_vector is None:
+            self._build_contact_vector()
         return self._contact_vector
 
     def add_probe(self, probe: Probe):
@@ -293,6 +295,9 @@ class ProbeGroup:
             n = probe.get_contact_count()
             probe.set_device_channel_indices(channels[ind : ind + n])
             ind += n
+
+        # invalidate the cache since channel ordering changed
+        self._contact_vector = None
 
     def get_global_contact_ids(self) -> np.ndarray:
         """

--- a/src/probeinterface/probegroup.py
+++ b/src/probeinterface/probegroup.py
@@ -13,13 +13,30 @@ class ProbeGroup:
 
     def __init__(self):
         self.probes = []
-        self._contact_vector = None
+        self._contact_vector_cache = None
 
     @property
-    def contact_vector(self):
-        if self._contact_vector is None:
+    def _contact_vector(self):
+        """
+        Channel-ordered dense view of the probegroup, built lazily on first access.
+
+        Private by convention: this handle is intended for integration with SpikeInterface
+        that needs a channel-ordered view for recording-facing queries. 
+        
+        Fields and dtype may evolve with consumer requirements, so user code should not depend on it directly. For stable probegroup state, use
+        the public `get_global_*` methods.
+
+        The cache is invalidated on probegroup-level mutations (`add_probe`,
+        `set_global_device_channel_indices`, `auto_generate_*`). Probe-level mutations
+        (for example `probe.move`, `probe.set_contact_ids`, direct writes to
+        `probe._contact_positions`) do NOT invalidate the cache by design: keeping
+        `ProbeGroup` unaware of `Probe` mutations avoids container/contained coupling.
+        Consumers that mutate a probe after attaching its probegroup must call
+        `_build_contact_vector()` explicitly to refresh.
+        """
+        if self._contact_vector_cache is None:
             self._build_contact_vector()
-        return self._contact_vector
+        return self._contact_vector_cache
 
     def add_probe(self, probe: Probe):
         """
@@ -36,7 +53,7 @@ class ProbeGroup:
 
         self.probes.append(probe)
         probe._probe_group = self
-        self._contact_vector = None
+        self._contact_vector_cache = None
 
     def _check_compatible(self, probe: Probe):
         if probe._probe_group is not None:
@@ -119,7 +136,7 @@ class ProbeGroup:
         order = np.argsort(channel_indices, kind="stable")
         contact_vector = contact_vector[order]
         contact_vector.setflags(write=False)
-        self._contact_vector = contact_vector
+        self._contact_vector_cache = contact_vector
 
     def to_numpy(self, complete: bool = False) -> np.ndarray:
         """
@@ -297,7 +314,7 @@ class ProbeGroup:
             ind += n
 
         # invalidate the cache since channel ordering changed
-        self._contact_vector = None
+        self._contact_vector_cache = None
 
     def get_global_contact_ids(self) -> np.ndarray:
         """
@@ -343,7 +360,7 @@ class ProbeGroup:
         probe_ids = generate_unique_ids(*args, **kwargs).astype(str)
         for pid, probe in enumerate(self.probes):
             probe.annotate(probe_id=probe_ids[pid])
-        self._contact_vector = None
+        self._contact_vector_cache = None
 
     def auto_generate_contact_ids(self, *args, **kwargs):
         """
@@ -366,4 +383,4 @@ class ProbeGroup:
         for probe in self.probes:
             el_ids, contact_ids = np.split(contact_ids, [probe.get_contact_count()])
             probe.set_contact_ids(el_ids)
-        self._contact_vector = None
+        self._contact_vector_cache = None

--- a/tests/test_probegroup.py
+++ b/tests/test_probegroup.py
@@ -135,46 +135,35 @@ def test_contact_vector_orders_connected_contacts():
     probegroup.add_probe(probe0)
     probegroup.add_probe(probe1)
 
-    probegroup._build_contact_vector()
-    arr = probegroup._contact_vector
+    arr = probegroup._build_contact_vector()
 
     assert arr.dtype.names == ("probe_index", "x", "y", "shank_ids", "contact_sides")
     assert arr.size == 3
-    assert arr.flags.writeable is False
     assert np.array_equal(arr["probe_index"], np.array([1, 1, 0]))
     assert np.array_equal(arr["x"], np.array([0.0, 20.0, 10.0]))
     assert np.array_equal(np.column_stack((arr["x"], arr["y"])), np.array([[0.0, 0.0], [20.0, 0.0], [10.0, 0.0]]))
 
 
-def test_contact_vector_cache_refresh_is_explicit():
+def test_contact_vector_reflects_current_probe_state():
     probegroup = ProbeGroup()
     probe = generate_dummy_probe()
     probe.set_device_channel_indices(np.arange(probe.get_contact_count()))
     probegroup.add_probe(probe)
 
-    probegroup._build_contact_vector()
-    dense_before = probegroup._contact_vector
-    dense_before_again = probegroup._contact_vector
-    assert dense_before is dense_before_again
-
+    dense_before = probegroup._build_contact_vector()
     original_positions = np.column_stack((dense_before["x"], dense_before["y"])).copy()
+
     probe.move([5.0, 0.0])
 
-    dense_after_move = probegroup._contact_vector
-    assert dense_after_move is dense_before
-    assert np.array_equal(np.column_stack((dense_after_move["x"], dense_after_move["y"])), original_positions)
-
-    probegroup._build_contact_vector()
-    dense_after_refresh = probegroup._contact_vector
-    assert dense_after_refresh is not dense_before
+    dense_after_move = probegroup._build_contact_vector()
+    assert dense_after_move is not dense_before
     assert np.array_equal(
-        np.column_stack((dense_after_refresh["x"], dense_after_refresh["y"])),
+        np.column_stack((dense_after_move["x"], dense_after_move["y"])),
         original_positions + np.array([5.0, 0.0]),
     )
 
     probe.set_shank_ids(np.array(["a"] * probe.get_contact_count()))
-    probegroup._build_contact_vector()
-    dense_with_shanks = probegroup._contact_vector
+    dense_with_shanks = probegroup._build_contact_vector()
     assert "shank_ids" in dense_with_shanks.dtype.names
 
 
@@ -193,8 +182,7 @@ def test_contact_vector_supports_3d_positions():
     probe.set_device_channel_indices(np.arange(probe.get_contact_count()))
     probegroup.add_probe(probe)
 
-    probegroup._build_contact_vector()
-    dense = probegroup._contact_vector
+    dense = probegroup._build_contact_vector()
     assert dense.dtype.names[:4] == ("probe_index", "x", "y", "z")
     assert np.column_stack((dense["x"], dense["y"], dense["z"])).shape[1] == 3
 

--- a/tests/test_probegroup.py
+++ b/tests/test_probegroup.py
@@ -116,6 +116,97 @@ def test_set_contact_ids_rejects_wrong_size():
         probe.set_contact_ids(["a", "b", "c"])
 
 
+def test_contact_vector_orders_connected_contacts():
+    from probeinterface import Probe
+
+    probe0 = Probe(ndim=2, si_units="um")
+    probe0.set_contacts(
+        positions=np.array([[10.0, 0.0], [30.0, 0.0]]),
+        shapes="circle",
+        shape_params={"radius": 5},
+        shank_ids=["s0", "s1"],
+        contact_sides=["front", "back"],
+    )
+    probe0.set_device_channel_indices([2, -1])
+
+    probe1 = Probe(ndim=2, si_units="um")
+    probe1.set_contacts(
+        positions=np.array([[0.0, 0.0], [20.0, 0.0]]),
+        shapes="circle",
+        shape_params={"radius": 5},
+        shank_ids=["s0", "s0"],
+        contact_sides=["front", "front"],
+    )
+    probe1.set_device_channel_indices([0, 1])
+
+    probegroup = ProbeGroup()
+    probegroup.add_probe(probe0)
+    probegroup.add_probe(probe1)
+
+    probegroup._build_contact_vector()
+    arr = probegroup.contact_vector
+
+    assert arr.dtype.names == ("probe_index", "x", "y", "shank_ids", "contact_sides")
+    assert arr.size == 3
+    assert arr.flags.writeable is False
+    assert np.array_equal(arr["probe_index"], np.array([1, 1, 0]))
+    assert np.array_equal(arr["x"], np.array([0.0, 20.0, 10.0]))
+    assert np.array_equal(np.column_stack((arr["x"], arr["y"])), np.array([[0.0, 0.0], [20.0, 0.0], [10.0, 0.0]]))
+
+
+def test_contact_vector_cache_refresh_is_explicit():
+    probegroup = ProbeGroup()
+    probe = generate_dummy_probe()
+    probe.set_device_channel_indices(np.arange(probe.get_contact_count()))
+    probegroup.add_probe(probe)
+
+    probegroup._build_contact_vector()
+    dense_before = probegroup.contact_vector
+    dense_before_again = probegroup.contact_vector
+    assert dense_before is dense_before_again
+
+    original_positions = np.column_stack((dense_before["x"], dense_before["y"])).copy()
+    probe.move([5.0, 0.0])
+
+    dense_after_move = probegroup.contact_vector
+    assert dense_after_move is dense_before
+    assert np.array_equal(np.column_stack((dense_after_move["x"], dense_after_move["y"])), original_positions)
+
+    probegroup._build_contact_vector()
+    dense_after_refresh = probegroup.contact_vector
+    assert dense_after_refresh is not dense_before
+    assert np.array_equal(
+        np.column_stack((dense_after_refresh["x"], dense_after_refresh["y"])),
+        original_positions + np.array([5.0, 0.0]),
+    )
+
+    probe.set_shank_ids(np.array(["a"] * probe.get_contact_count()))
+    probegroup._build_contact_vector()
+    dense_with_shanks = probegroup.contact_vector
+    assert "shank_ids" in dense_with_shanks.dtype.names
+
+
+def test_contact_vector_requires_wired_contacts():
+    probegroup = ProbeGroup()
+    probe = generate_dummy_probe()
+    probegroup.add_probe(probe)
+
+    with pytest.raises(ValueError, match="requires at least one wired contact"):
+        probegroup._build_contact_vector()
+
+
+def test_contact_vector_supports_3d_positions():
+    probegroup = ProbeGroup()
+    probe = generate_dummy_probe().to_3d()
+    probe.set_device_channel_indices(np.arange(probe.get_contact_count()))
+    probegroup.add_probe(probe)
+
+    probegroup._build_contact_vector()
+    dense = probegroup.contact_vector
+    assert dense.dtype.names[:4] == ("probe_index", "x", "y", "z")
+    assert np.column_stack((dense["x"], dense["y"], dense["z"])).shape[1] == 3
+
+
 if __name__ == "__main__":
     test_probegroup()
     # ~ test_probegroup_3d()

--- a/tests/test_probegroup.py
+++ b/tests/test_probegroup.py
@@ -144,7 +144,7 @@ def test_contact_vector_orders_connected_contacts():
     probegroup.add_probe(probe1)
 
     probegroup._build_contact_vector()
-    arr = probegroup.contact_vector
+    arr = probegroup._contact_vector
 
     assert arr.dtype.names == ("probe_index", "x", "y", "shank_ids", "contact_sides")
     assert arr.size == 3
@@ -161,19 +161,19 @@ def test_contact_vector_cache_refresh_is_explicit():
     probegroup.add_probe(probe)
 
     probegroup._build_contact_vector()
-    dense_before = probegroup.contact_vector
-    dense_before_again = probegroup.contact_vector
+    dense_before = probegroup._contact_vector
+    dense_before_again = probegroup._contact_vector
     assert dense_before is dense_before_again
 
     original_positions = np.column_stack((dense_before["x"], dense_before["y"])).copy()
     probe.move([5.0, 0.0])
 
-    dense_after_move = probegroup.contact_vector
+    dense_after_move = probegroup._contact_vector
     assert dense_after_move is dense_before
     assert np.array_equal(np.column_stack((dense_after_move["x"], dense_after_move["y"])), original_positions)
 
     probegroup._build_contact_vector()
-    dense_after_refresh = probegroup.contact_vector
+    dense_after_refresh = probegroup._contact_vector
     assert dense_after_refresh is not dense_before
     assert np.array_equal(
         np.column_stack((dense_after_refresh["x"], dense_after_refresh["y"])),
@@ -182,7 +182,7 @@ def test_contact_vector_cache_refresh_is_explicit():
 
     probe.set_shank_ids(np.array(["a"] * probe.get_contact_count()))
     probegroup._build_contact_vector()
-    dense_with_shanks = probegroup.contact_vector
+    dense_with_shanks = probegroup._contact_vector
     assert "shank_ids" in dense_with_shanks.dtype.names
 
 
@@ -202,7 +202,7 @@ def test_contact_vector_supports_3d_positions():
     probegroup.add_probe(probe)
 
     probegroup._build_contact_vector()
-    dense = probegroup.contact_vector
+    dense = probegroup._contact_vector
     assert dense.dtype.names[:4] == ("probe_index", "x", "y", "z")
     assert np.column_stack((dense["x"], dense["y"], dense["z"])).shape[1] == 3
 


### PR DESCRIPTION
Coming here from #420

This PR adds a private `_build_contact_vector()` method on `ProbeGroup`. The method returns a dense channel-ordered numpy array derived from the current `device_channel_indices`:

```python
>>> probegroup._build_contact_vector()
array([(0,  0.,  0., '0', 'front'),
       (0, 20.,  0., '0', 'front'),
       (0,  0., 20., '1', 'back'),
       (0, 20., 20., '1', 'back')],
      dtype=[('probe_index', '<i8'), ('x', '<f8'), ('y', '<f8'), ('shank_ids', '<U64'), ('contact_sides', '<U8')])
```

It contains only the subset of state SpikeInterface actually needs in channel order: `probe_index`, `x`, `y`, `z`, `shank_ids`, and `contact_sides`. Fields that are not available on the `ProbeGroup` are not included in the representation. The method is private by convention: it is intended for integration with downstream libraries (notably SpikeInterface), and its fields and dtype may evolve with consumer requirements, so user code should not depend on it directly.

This PR enables a middle way between the old `contact_vector` workflow we are currently using in SpikeInterface and the full array-backed rewrite of `ProbeGroup` proposed in #420. #420 changes the identity of `ProbeGroup` itself to become an array-backed backend; this PR keeps the scope smaller and adds a private method that returns only what SpikeInterface needs. The coupling between probeinterface and SpikeInterface now lives in one small surface (`_build_contact_vector()`) instead of being spread through the whole `ProbeGroup` class, so the two libraries can evolve together without requiring larger changes on either side. This provides the probeinterface-side handle needed for the SpikeInterface [#4465](https://github.com/SpikeInterface/spikeinterface/pull/4465) direction, where the recording holds a `ProbeGroup` object directly and recovers the channel-facing behavior through this handle on demand.

Three technical points:

- **SpikeInterface integration.** The method computes fresh from each probe's current `device_channel_indices`. Consumers call `probegroup._build_contact_vector()` and get a view reflecting the probegroup's current state: no cache to keep in sync, no invalidation rules, no probe-level vs probegroup-level distinction. If a consumer needs to avoid repeated recomputation in a hot loop, it can cache the result at the call site where it knows the lifetime.

- **Private to make it flexible.** The method is private because its fields and dtype are tailored to SpikeInterface's current needs and will evolve with them. As a private method, the handle can grow, shrink, or change shape without becoming a public-API break. This mechanism is for SpikeInterface and for power users who know the contract, so let's keep it private.

- **No serialization format change.** The method has no in-memory state; it computes fresh from each probe's own `device_channel_indices`, which already round-trip through probe serialization. So this PR needs no format version bump and no new way to encode channel order in the JSON/dict representation. The existing per-probe serialization is sufficient. Because the method derives from `device_channel_indices` rather than replacing it, a consumer could also preserve the user-provided wiring as provenance and still obtain a channel-ordered view.

The companion [SpikeInterface PR](https://github.com/SpikeInterface/spikeinterface/pull/4531) illustrates the implementation of this.
