### PR TITLE
Annotate `probe_type` on probes built via `read_spikeglx`

### DIFF
--- a/src/probeinterface/neuropixels_tools.py
+++ b/src/probeinterface/neuropixels_tools.py
@@ -865,6 +865,7 @@ def read_spikeglx(file: str | Path) -> Probe:
     probe.annotate(part_number=imDatPrb_pn)
     probe.annotate(port=imDatPrb_port)
     probe.annotate(slot=imDatPrb_slot)
+    probe.annotate(probe_type=probe_part_number_to_probe_type.get(imDatPrb_pn))
 
     # ===== 8. Set device channel indices (wiring) =====
     probe.set_device_channel_indices(np.arange(probe.get_contact_count()))

--- a/tests/test_io/test_spikeglx.py
+++ b/tests/test_io/test_spikeglx.py
@@ -46,6 +46,7 @@ def test_NP1():
     assert "1.0" in probe.description
     assert "adc_group" in probe.contact_annotations
     assert "adc_sample_order" in probe.contact_annotations
+    assert probe.annotations.get("probe_type") == "0"
 
 
 def test_NP_phase3A():


### PR DESCRIPTION
Closes #424. This is a mistake from #410: when I rewrote `read_spikeglx` to share the catalogue-based construction path with `read_imro`, I forgot to port the `probe_type` annotation over. Before that refactor, `read_spikeglx` called `probe.annotate(probe_type=probe_type)`. Afterwards, `read_imro` kept the annotation but `read_spikeglx` no longer set it, so downstream code reading `recording.get_annotation("probes_info")[0]["probe_type"]` broke silently. This PR carries those lines over by deriving `probe_type` from `imDatPrb_pn` through the existing `probe_part_number_to_probe_type` mapping, and adds a regression assertion in `test_NP1`.
