### PR TITLE
Raise on wrong-sized `device_channel_indices` instead of silently accepting

### DIFF
--- a/src/probeinterface/probe.py
+++ b/src/probeinterface/probe.py
@@ -527,7 +527,7 @@ class Probe:
         """
         channel_indices = np.asarray(channel_indices, dtype=int)
         if channel_indices.size != self.get_contact_count():
-            ValueError(
+            raise ValueError(
                 f"channel_indices {channel_indices.size} do not have "
                 f"the same size as contacts {self.get_contact_count()}"
             )

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -141,6 +141,19 @@ def test_probe():
     # ~ plt.show()
 
 
+def test_set_device_channel_indices_rejects_wrong_size():
+    """Setting device_channel_indices with wrong count raises ValueError."""
+    probe = Probe(ndim=2, si_units="um")
+    probe.set_contacts(
+        positions=np.array([[0, 0], [10, 0], [20, 0]]),
+        shapes="circle",
+        shape_params={"radius": 5},
+    )
+
+    with pytest.raises(ValueError, match="do not have"):
+        probe.set_device_channel_indices([0, 1])
+
+
 def test_probe_equality_dunder():
     probe1 = generate_dummy_probe()
     probe2 = generate_dummy_probe()


### PR DESCRIPTION
`Probe.set_device_channel_indices` was constructing a `ValueError` on size mismatch but never raising it, so wrong-sized wiring arrays were stored and the probe silently ended up in an invalid state. Added the missing `raise` and a regression test that passes two indices to a three-contact probe and asserts the error.
