### PR TITLE
Discard 'apps' folder when listing manufacturers

### DIFF
--- a/src/probeinterface/library.py
+++ b/src/probeinterface/library.py
@@ -291,5 +291,5 @@ def list_github_folders(owner: str, repo: str, path: str = "", ref: str = None, 
     return [
         item["name"]
         for item in items
-        if item.get("type") == "dir" and item["name"][0] != "." and item["name"] != "scripts"
+        if item.get("type") == "dir" and item["name"][0] != "." and item["name"] not in ["scripts", "apps"]
     ]


### PR DESCRIPTION
After the probe-viewer was ported to the `probeinterface_library`, we have to discard the `apps` folder when listing manufacturers