### PR TITLE
Document contact_id uniqueness and enforce it on (probe_index, contact_id)

### DIFF
--- a/src/probeinterface/probe.py
+++ b/src/probeinterface/probe.py
@@ -110,7 +110,9 @@ class Probe:
         self.device_channel_indices = None
 
         # Handle ids with str so it can be displayed like names
-        #  This must be unique at Probe AND ProbeGroup level
+        #  This must be unique at Probe level. Across a ProbeGroup the key that is
+        #  unique is the pair (probe_index, contact_id), so two copies of the same
+        #  probe model keep their own contact_ids without clashing.
         self._contact_ids = None
 
         # Handle contact side for double face probes
@@ -560,8 +562,13 @@ class Probe:
     def set_contact_ids(self, contact_ids: np.ndarray | list):
         """
         Set contact ids. Channel ids are converted to strings.
-        Contact ids must be **unique** for the **Probe**
-        and also for the **ProbeGroup**
+        Contact ids must be **unique** within the **Probe**.
+
+        They are *not* required to be unique across a **ProbeGroup**: the key that is
+        unique there is the pair ``(probe_index, contact_id)``. Adding the same probe
+        model to a ProbeGroup twice therefore keeps both sets of contact_ids as they
+        are, and :meth:`ProbeGroup.select_contacts` takes ``probe_ids`` to disambiguate
+        a contact_id that appears on more than one probe.
 
         Parameters
         ----------

--- a/src/probeinterface/probegroup.py
+++ b/src/probeinterface/probegroup.py
@@ -356,6 +356,10 @@ class ProbeGroup:
         """
         Gets all contact ids concatenated across probes
 
+        Contact ids are unique within a Probe but may repeat across probes, so the
+        returned array is not necessarily unique. Pair it with the ``probe_index``
+        column of :meth:`to_numpy` to get a key that is unique across the ProbeGroup.
+
         Returns
         -------
         contact_ids: np.ndarray
@@ -546,13 +550,28 @@ Some contact ids are ambiguous because they live on multiple probes; pass probe_
         return self.get_slice(indices)
 
     def _check_global_device_wiring_and_ids(self) -> None:
+        if self.get_contact_count() == 0:
+            return
+        arr = self.to_numpy(complete=True)
+
         # check unique device_channel_indices for !=-1
-        chans = self.get_global_device_channel_indices()
-        keep = chans["device_channel_indices"] >= 0
-        valid_chans = chans[keep]["device_channel_indices"]
+        chans = arr["device_channel_indices"]
+        valid_chans = chans[chans >= 0]
 
         if valid_chans.size != np.unique(valid_chans).size:
             raise ValueError("channel device indices are not unique across probes")
+
+        # check unique contact ids. A contact_id is unique within a Probe, not across
+        # the whole ProbeGroup, so the key that has to be unique here is the pair
+        # (probe_index, contact_id). This lets the same probe model be added twice
+        # without renaming its contacts, while still identifying every contact.
+        pairs = list(zip(arr["probe_index"].tolist(), arr["contact_ids"].tolist()))
+        if len(set(pairs)) != len(pairs):
+            duplicated = sorted({pair for pair in pairs if pairs.count(pair) > 1})
+            raise ValueError(
+                f"(probe_index, contact_id) pairs are not unique across probes: {duplicated}. "
+                "contact_ids only need to be unique within a single Probe."
+            )
 
     def auto_generate_contact_ids(self, *args, **kwargs) -> None:
         """

--- a/tests/test_probegroup.py
+++ b/tests/test_probegroup.py
@@ -102,6 +102,56 @@ def test_set_contact_ids_rejects_wrong_size():
         probe.set_contact_ids(["a", "b", "c"])
 
 
+def test_duplicate_contact_ids_across_probes_are_allowed():
+    """contact_ids are unique per Probe, not per ProbeGroup.
+
+    Adding the same probe model twice must not rename anything and must not raise.
+    """
+    probegroup = ProbeGroup()
+    for _ in range(2):
+        probe = generate_dummy_probe()
+        probe.set_contact_ids([str(i) for i in range(probe.get_contact_count())])
+        probegroup.add_probe(probe)
+
+    arr = probegroup.to_numpy(complete=True)
+    contact_ids = arr["contact_ids"].tolist()
+
+    # the ids themselves repeat across the two probes
+    assert len(set(contact_ids)) < len(contact_ids)
+    # but (probe_index, contact_id) is unique, which is the ProbeGroup-level key
+    pairs = list(zip(arr["probe_index"].tolist(), contact_ids))
+    assert len(set(pairs)) == len(pairs)
+
+
+def test_generate_dummy_probe_group_repeats_contact_ids_across_probes():
+    """Guards the documented semantics against a return to group-wide uniqueness."""
+    from probeinterface import generate_dummy_probe_group
+
+    arr = generate_dummy_probe_group().to_numpy(complete=True)
+    contact_ids = arr["contact_ids"].tolist()
+
+    assert len(set(contact_ids)) < len(contact_ids)
+    pairs = list(zip(arr["probe_index"].tolist(), contact_ids))
+    assert len(set(pairs)) == len(pairs)
+
+
+def test_check_global_ids_rejects_within_probe_duplicates():
+    """The ProbeGroup-level check validates ids, not just device_channel_indices.
+
+    ``set_contact_ids`` already blocks within-probe duplicates, so this reaches the
+    group check the way a Probe built by other means (for example an older
+    serialized file) would.
+    """
+    probegroup = _make_probegroup()
+    probe = probegroup.probes[0]
+    duplicated = probe.contact_ids.copy()
+    duplicated[1] = duplicated[0]
+    probe._contact_ids = duplicated
+
+    with pytest.raises(ValueError, match=r"\(probe_index, contact_id\) pairs are not unique"):
+        probegroup._check_global_device_wiring_and_ids()
+
+
 # ── get_global_contact_positions() tests ────────────────────────────────────
 
 


### PR DESCRIPTION
Fixes #402.

`Probe.__init__` and `set_contact_ids` both promised contact_ids are unique at Probe and ProbeGroup level, but cross-probe enforcement was removed in #229 and the docs were never updated. `_check_global_device_wiring_and_ids` validated only `device_channel_indices` despite its name covering ids.

This follows the design agreed in the thread: contact_ids stay unique within a Probe, and the key unique across a ProbeGroup is the pair `(probe_index, contact_id)`. Downloading the same probe model twice and putting both in a ProbeGroup keeps their contact_ids as they are, which is the expected behaviour.

`_check_global_device_wiring_and_ids` now validates the compound key, so the method matches its name. The `Probe.__init__` comment, the `set_contact_ids` docstring and the `get_global_contact_ids` docstring now describe the real semantics and point at `probe_ids` for disambiguating an id shared by several probes. Both checks now share a single `to_numpy` call rather than one each.

Tests: `test_duplicate_contact_ids_across_probes_are_allowed` and `test_generate_dummy_probe_group_repeats_contact_ids_across_probes` lock in the agreed semantics, and would fail if group-wide uniqueness were restored. `test_check_global_ids_rejects_within_probe_duplicates` covers the newly real check.

Worth noting as the concrete case this has to permit: the dummy probe group has 64 contacts but only 32 unique contact_ids, with all 64 compound keys unique. That is now a test.

Reverting the source from the base ref makes the new check test fail with `DID NOT RAISE ValueError`. The two semantics tests pass in both halves by design, since they are regression guards on existing behaviour. Full suite is green at 191 passed and 1 skipped.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
